### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ An MCP server implementation that integrates with Contentful's Content Managemen
   clone this repo, you can just set it up in Claude desktop, refer to the section
   "Usage with Claude Desktop" for instructions on how to install it.
 
+<a href="https://glama.ai/mcp/servers/l2fxeaot4p"><img width="380" height="200" src="https://glama.ai/mcp/servers/l2fxeaot4p/badge" alt="contentful-mcp MCP server" /></a>
+
 ## Features
 
 - **Content Management**: Full CRUD operations for entries and assets


### PR DESCRIPTION
This PR adds a badge for the contentful-mcp server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/l2fxeaot4p"><img width="380" height="200" src="https://glama.ai/mcp/servers/l2fxeaot4p/badge" alt="contentful-mcp MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.