### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Contentful MCP Server
+[![smithery badge](https://smithery.ai/badge/@ivotoby/contentful-management-mcp-server)](https://smithery.ai/server/@ivotoby/contentful-management-mcp-server)
 
 An MCP server implementation that integrates with Contentful's Content Management API, providing comprehensive content management capabilities.
 
@@ -98,6 +99,14 @@ and add the following lines:
     }
   }
 }
+```
+
+### Installing via Smithery
+
+To install Contentful Management Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@ivotoby/contentful-management-mcp-server):
+
+```bash
+npx -y @smithery/cli install @ivotoby/contentful-management-mcp-server --client claude
 ```
 
 ### Developing and using Claude desktop


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Contentful Management Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@ivotoby/contentful-management-mcp-server

Let me know if any tweaks have to be made!