### PR TITLE
feat(bulk actions): add bulk actions handlers and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ An MCP server implementation that integrates with Contentful's Content Managemen
 - **Content Types**: Manage content type definitions
 - **Localization**: Support for multiple locales
 - **Publishing**: Control content publishing workflow
+- **Bulk Operations**: Execute bulk publishing, unpublishing, and validation across multiple entries and assets
 - **Smart Pagination**: List operations return maximum 3 items per request to prevent context window overflow, with built-in pagination support
 
 ## Pagination
@@ -31,6 +32,17 @@ To prevent context window overflow in LLMs, list operations (like search_entries
 
 This pagination system allows the LLM to efficiently handle large datasets while maintaining context window limits.
 
+## Bulk Operations
+
+The bulk operations feature provides efficient management of multiple content items simultaneously:
+
+- **Asynchronous Processing**: Operations run asynchronously and provide status updates
+- **Efficient Content Management**: Process multiple entries or assets in a single API call
+- **Status Tracking**: Monitor progress with success and failure counts
+- **Resource Optimization**: Reduce API calls and improve performance for batch operations
+
+These bulk operation tools are ideal for content migrations, mass updates, or batch publishing workflows.
+
 ## Tools
 
 ### Entry Management
@@ -42,6 +54,12 @@ This pagination system allows the LLM to efficiently handle large datasets while
 - **delete_entry**: Remove entries
 - **publish_entry**: Publish entries
 - **unpublish_entry**: Unpublish entries
+
+### Bulk Operations
+
+- **bulk_publish**: Publish multiple entries and assets in a single operation. Accepts an array of entities (entries and assets) and processes their publication as a batch.
+- **bulk_unpublish**: Unpublish multiple entries and assets in a single operation. Similar to bulk_publish but removes content from the delivery API.
+- **bulk_validate**: Validate multiple entries for content consistency, references, and required fields. Returns validation results without modifying content.
 
 ### Asset Management
 
@@ -80,6 +98,7 @@ The project includes an MCP Inspector tool that helps with development and debug
 - **Watch Mode**: Use `npm run inspect:watch` to automatically restart the inspector when files change
 - **Visual Interface**: The inspector provides a web interface to test and debug MCP tools
 - **Real-time Testing**: Try out tools and see their responses immediately
+- **Bulk Operations Testing**: Test and monitor bulk operations with visual feedback on progress and results
 
 The project also contains a `npm run dev` command which rebuilds and reloads the MCP server on every change.
 

--- a/src/handlers/bulk-action-handlers.ts
+++ b/src/handlers/bulk-action-handlers.ts
@@ -40,65 +40,65 @@ export const bulkActionHandlers = {
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
 
     const contentfulClient = await getContentfulClient()
-    
+
     // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.publish(
       {
         spaceId,
         environmentId,
-      }, 
+      },
       {
         entities: {
           sys: {
             type: "Array",
           },
-          items: args.entities.map(entity => ({
+          items: args.entities.map((entity) => ({
             sys: {
               type: "Link",
               linkType: entity.sys.type,
-              id: entity.sys.id
-            }
+              id: entity.sys.id,
+            },
           })),
         },
-      }
+      },
     )
-    
+
     // Wait for the bulk action to complete
-    let action = await contentfulClient.bulkAction.get({
+    let action = (await contentfulClient.bulkAction.get({
       spaceId,
       environmentId,
-      bulkActionId: bulkAction.sys.id
-    }) as unknown as BulkActionResponse
-    
+      bulkActionId: bulkAction.sys.id,
+    })) as unknown as BulkActionResponse
+
     while (action.sys.status === "inProgress" || action.sys.status === "created") {
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      action = await contentfulClient.bulkAction.get({
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      action = (await contentfulClient.bulkAction.get({
         spaceId,
         environmentId,
-        bulkActionId: bulkAction.sys.id
-      }) as unknown as BulkActionResponse
+        bulkActionId: bulkAction.sys.id,
+      })) as unknown as BulkActionResponse
     }
-    
+
     return {
       content: [
-        { 
-          type: "text", 
+        {
+          type: "text",
           text: `Bulk publish completed with status: ${action.sys.status}. ${
-            action.sys.status === "failed" 
-              ? `Error: ${JSON.stringify(action.error)}` 
+            action.sys.status === "failed"
+              ? `Error: ${JSON.stringify(action.error)}`
               : `Successfully processed ${action.succeeded?.length || 0} items.`
-          }`
-        }
+          }`,
+        },
       ],
     }
   },
-  
+
   bulkUnpublish: async (args: BulkUnpublishParams) => {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
 
     const contentfulClient = await getContentfulClient()
-    
+
     // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.unpublish(
       {
@@ -110,53 +110,53 @@ export const bulkActionHandlers = {
           sys: {
             type: "Array",
           },
-          items: args.entities.map(entity => ({
+          items: args.entities.map((entity) => ({
             sys: {
               type: "Link",
               linkType: entity.sys.type,
-              id: entity.sys.id
-            }
+              id: entity.sys.id,
+            },
           })),
         },
-      }
+      },
     )
-    
+
     // Wait for the bulk action to complete
-    let action = await contentfulClient.bulkAction.get({
+    let action = (await contentfulClient.bulkAction.get({
       spaceId,
       environmentId,
-      bulkActionId: bulkAction.sys.id
-    }) as unknown as BulkActionResponse
-    
+      bulkActionId: bulkAction.sys.id,
+    })) as unknown as BulkActionResponse
+
     while (action.sys.status === "inProgress" || action.sys.status === "created") {
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      action = await contentfulClient.bulkAction.get({
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      action = (await contentfulClient.bulkAction.get({
         spaceId,
         environmentId,
-        bulkActionId: bulkAction.sys.id
-      }) as unknown as BulkActionResponse
+        bulkActionId: bulkAction.sys.id,
+      })) as unknown as BulkActionResponse
     }
-    
+
     return {
       content: [
-        { 
-          type: "text", 
+        {
+          type: "text",
           text: `Bulk unpublish completed with status: ${action.sys.status}. ${
-            action.sys.status === "failed" 
-              ? `Error: ${JSON.stringify(action.error)}` 
+            action.sys.status === "failed"
+              ? `Error: ${JSON.stringify(action.error)}`
               : `Successfully processed ${action.succeeded?.length || 0} items.`
-          }`
-        }
+          }`,
+        },
       ],
     }
   },
-  
+
   bulkValidate: async (args: BulkValidateParams) => {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
 
     const contentfulClient = await getContentfulClient()
-    
+
     // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.validate(
       {
@@ -168,44 +168,44 @@ export const bulkActionHandlers = {
           sys: {
             type: "Array",
           },
-          items: args.entryIds.map(id => ({
+          items: args.entryIds.map((id) => ({
             sys: {
               type: "Link",
               linkType: "Entry",
-              id
-            }
+              id,
+            },
           })),
         },
-      }
+      },
     )
-    
+
     // Wait for the bulk action to complete
-    let action = await contentfulClient.bulkAction.get({
+    let action = (await contentfulClient.bulkAction.get({
       spaceId,
       environmentId,
-      bulkActionId: bulkAction.sys.id
-    }) as unknown as BulkActionResponse
-    
+      bulkActionId: bulkAction.sys.id,
+    })) as unknown as BulkActionResponse
+
     while (action.sys.status === "inProgress" || action.sys.status === "created") {
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      action = await contentfulClient.bulkAction.get({
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      action = (await contentfulClient.bulkAction.get({
         spaceId,
         environmentId,
-        bulkActionId: bulkAction.sys.id
-      }) as unknown as BulkActionResponse
+        bulkActionId: bulkAction.sys.id,
+      })) as unknown as BulkActionResponse
     }
-    
+
     return {
       content: [
-        { 
-          type: "text", 
+        {
+          type: "text",
           text: `Bulk validation completed with status: ${action.sys.status}. ${
-            action.sys.status === "failed" 
-              ? `Error: ${JSON.stringify(action.error)}` 
+            action.sys.status === "failed"
+              ? `Error: ${JSON.stringify(action.error)}`
               : `Successfully validated ${action.succeeded?.length || 0} entries.`
-          }`
-        }
+          }`,
+        },
       ],
     }
-  }
+  },
 }

--- a/src/handlers/bulk-action-handlers.ts
+++ b/src/handlers/bulk-action-handlers.ts
@@ -11,6 +11,21 @@ type BulkPublishParams = {
   }>
 }
 
+// Define the correct types for bulk action responses
+interface BulkActionResponse {
+  sys: {
+    id: string
+    status: string
+  }
+  succeeded?: Array<{
+    sys: {
+      id: string
+      type: string
+    }
+  }>
+  error?: any
+}
+
 type BulkUnpublishParams = BulkPublishParams
 
 type BulkValidateParams = {
@@ -37,7 +52,13 @@ export const bulkActionHandlers = {
           sys: {
             type: "Array",
           },
-          items: args.entities,
+          items: args.entities.map(entity => ({
+            sys: {
+              type: "Link",
+              linkType: entity.sys.type,
+              id: entity.sys.id
+            }
+          })),
         },
       }
     )
@@ -47,7 +68,7 @@ export const bulkActionHandlers = {
       spaceId,
       environmentId,
       bulkActionId: bulkAction.sys.id
-    })
+    }) as unknown as BulkActionResponse
     
     while (action.sys.status === "inProgress" || action.sys.status === "created") {
       await new Promise(resolve => setTimeout(resolve, 1000))
@@ -55,7 +76,7 @@ export const bulkActionHandlers = {
         spaceId,
         environmentId,
         bulkActionId: bulkAction.sys.id
-      })
+      }) as unknown as BulkActionResponse
     }
     
     return {
@@ -89,7 +110,13 @@ export const bulkActionHandlers = {
           sys: {
             type: "Array",
           },
-          items: args.entities,
+          items: args.entities.map(entity => ({
+            sys: {
+              type: "Link",
+              linkType: entity.sys.type,
+              id: entity.sys.id
+            }
+          })),
         },
       }
     )
@@ -99,7 +126,7 @@ export const bulkActionHandlers = {
       spaceId,
       environmentId,
       bulkActionId: bulkAction.sys.id
-    })
+    }) as unknown as BulkActionResponse
     
     while (action.sys.status === "inProgress" || action.sys.status === "created") {
       await new Promise(resolve => setTimeout(resolve, 1000))
@@ -107,7 +134,7 @@ export const bulkActionHandlers = {
         spaceId,
         environmentId,
         bulkActionId: bulkAction.sys.id
-      })
+      }) as unknown as BulkActionResponse
     }
     
     return {
@@ -157,7 +184,7 @@ export const bulkActionHandlers = {
       spaceId,
       environmentId,
       bulkActionId: bulkAction.sys.id
-    })
+    }) as unknown as BulkActionResponse
     
     while (action.sys.status === "inProgress" || action.sys.status === "created") {
       await new Promise(resolve => setTimeout(resolve, 1000))
@@ -165,7 +192,7 @@ export const bulkActionHandlers = {
         spaceId,
         environmentId,
         bulkActionId: bulkAction.sys.id
-      })
+      }) as unknown as BulkActionResponse
     }
     
     return {

--- a/src/handlers/bulk-action-handlers.ts
+++ b/src/handlers/bulk-action-handlers.ts
@@ -26,6 +26,16 @@ interface BulkActionResponse {
   error?: any
 }
 
+// Define the correct types for bulk action payloads
+interface VersionedLink {
+  sys: {
+    type: "Link"
+    linkType: "Entry" | "Asset"
+    id: string
+    version?: number
+  }
+}
+
 type BulkUnpublishParams = BulkPublishParams
 
 type BulkValidateParams = {
@@ -41,6 +51,45 @@ export const bulkActionHandlers = {
 
     const contentfulClient = await getContentfulClient()
 
+    // Get the current version of each entity
+    const entityVersions: VersionedLink[] = await Promise.all(
+      args.entities.map(async (entity) => {
+        try {
+          // Get the current version of the entity
+          const currentEntity = entity.sys.type === "Entry" 
+            ? await contentfulClient.entry.get({
+                spaceId,
+                environmentId,
+                entryId: entity.sys.id
+              })
+            : await contentfulClient.asset.get({
+                spaceId,
+                environmentId,
+                assetId: entity.sys.id
+              });
+          
+          return {
+            sys: {
+              type: "Link",
+              linkType: entity.sys.type,
+              id: entity.sys.id,
+              version: currentEntity.sys.version
+            }
+          };
+        } catch (error) {
+          console.error(`Error fetching entity ${entity.sys.id}: ${error}`);
+          // Return without version if we can't get it
+          return {
+            sys: {
+              type: "Link",
+              linkType: entity.sys.type,
+              id: entity.sys.id
+            }
+          };
+        }
+      })
+    );
+
     // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.publish(
       {
@@ -52,13 +101,7 @@ export const bulkActionHandlers = {
           sys: {
             type: "Array",
           },
-          items: args.entities.map((entity) => ({
-            sys: {
-              type: "Link",
-              linkType: entity.sys.type,
-              id: entity.sys.id,
-            },
-          })),
+          items: entityVersions,
         },
       },
     )
@@ -99,6 +142,45 @@ export const bulkActionHandlers = {
 
     const contentfulClient = await getContentfulClient()
 
+    // Get the current version of each entity
+    const entityVersions: VersionedLink[] = await Promise.all(
+      args.entities.map(async (entity) => {
+        try {
+          // Get the current version of the entity
+          const currentEntity = entity.sys.type === "Entry" 
+            ? await contentfulClient.entry.get({
+                spaceId,
+                environmentId,
+                entryId: entity.sys.id
+              })
+            : await contentfulClient.asset.get({
+                spaceId,
+                environmentId,
+                assetId: entity.sys.id
+              });
+          
+          return {
+            sys: {
+              type: "Link",
+              linkType: entity.sys.type,
+              id: entity.sys.id,
+              version: currentEntity.sys.version
+            }
+          };
+        } catch (error) {
+          console.error(`Error fetching entity ${entity.sys.id}: ${error}`);
+          // Return without version if we can't get it
+          return {
+            sys: {
+              type: "Link",
+              linkType: entity.sys.type,
+              id: entity.sys.id
+            }
+          };
+        }
+      })
+    );
+
     // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.unpublish(
       {
@@ -110,13 +192,7 @@ export const bulkActionHandlers = {
           sys: {
             type: "Array",
           },
-          items: args.entities.map((entity) => ({
-            sys: {
-              type: "Link",
-              linkType: entity.sys.type,
-              id: entity.sys.id,
-            },
-          })),
+          items: entityVersions,
         },
       },
     )
@@ -157,6 +233,39 @@ export const bulkActionHandlers = {
 
     const contentfulClient = await getContentfulClient()
 
+    // Get the current version of each entry
+    const entityVersions: VersionedLink[] = await Promise.all(
+      args.entryIds.map(async (id) => {
+        try {
+          // Get the current version of the entry
+          const currentEntry = await contentfulClient.entry.get({
+            spaceId,
+            environmentId,
+            entryId: id
+          });
+          
+          return {
+            sys: {
+              type: "Link",
+              linkType: "Entry",
+              id,
+              version: currentEntry.sys.version
+            }
+          };
+        } catch (error) {
+          console.error(`Error fetching entry ${id}: ${error}`);
+          // Return without version if we can't get it
+          return {
+            sys: {
+              type: "Link",
+              linkType: "Entry",
+              id
+            }
+          };
+        }
+      })
+    );
+
     // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.validate(
       {
@@ -168,13 +277,7 @@ export const bulkActionHandlers = {
           sys: {
             type: "Array",
           },
-          items: args.entryIds.map((id) => ({
-            sys: {
-              type: "Link",
-              linkType: "Entry",
-              id,
-            },
-          })),
+          items: entityVersions,
         },
       },
     )

--- a/src/handlers/bulk-action-handlers.ts
+++ b/src/handlers/bulk-action-handlers.ts
@@ -27,9 +27,10 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
     
     // Create the bulk action
-    const bulkAction = await contentfulClient.environment.createPublishBulkAction({
+    const bulkAction = await contentfulClient.bulkAction.publish({
       spaceId,
       environmentId,
+      action: "publish",
       payload: {
         entities: {
           sys: {
@@ -47,7 +48,7 @@ export const bulkActionHandlers = {
       bulkActionId: bulkAction.sys.id
     })
     
-    while (action.sys.status === "inProgress") {
+    while (action.sys.status === "inProgress" || action.sys.status === "created") {
       await new Promise(resolve => setTimeout(resolve, 1000))
       action = await contentfulClient.bulkAction.get({
         spaceId,
@@ -77,9 +78,10 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
     
     // Create the bulk action
-    const bulkAction = await contentfulClient.environment.createUnpublishBulkAction({
+    const bulkAction = await contentfulClient.bulkAction.unpublish({
       spaceId,
       environmentId,
+      action: "unpublish",
       payload: {
         entities: {
           sys: {
@@ -97,7 +99,7 @@ export const bulkActionHandlers = {
       bulkActionId: bulkAction.sys.id
     })
     
-    while (action.sys.status === "inProgress") {
+    while (action.sys.status === "inProgress" || action.sys.status === "created") {
       await new Promise(resolve => setTimeout(resolve, 1000))
       action = await contentfulClient.bulkAction.get({
         spaceId,
@@ -127,9 +129,10 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
     
     // Create the bulk action
-    const bulkAction = await contentfulClient.environment.createValidateBulkAction({
+    const bulkAction = await contentfulClient.bulkAction.validate({
       spaceId,
       environmentId,
+      action: "validate",
       payload: {
         entities: {
           sys: {
@@ -153,7 +156,7 @@ export const bulkActionHandlers = {
       bulkActionId: bulkAction.sys.id
     })
     
-    while (action.sys.status === "inProgress") {
+    while (action.sys.status === "inProgress" || action.sys.status === "created") {
       await new Promise(resolve => setTimeout(resolve, 1000))
       action = await contentfulClient.bulkAction.get({
         spaceId,

--- a/src/handlers/bulk-action-handlers.ts
+++ b/src/handlers/bulk-action-handlers.ts
@@ -27,19 +27,20 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
     
     // Create the bulk action
-    const bulkAction = await contentfulClient.bulkAction.publish({
-      spaceId,
-      environmentId,
-      action: "publish",
-      payload: {
+    const bulkAction = await contentfulClient.bulkAction.publish(
+      {
+        spaceId,
+        environmentId,
+      }, 
+      {
         entities: {
           sys: {
             type: "Array",
           },
           items: args.entities,
         },
-      },
-    })
+      }
+    )
     
     // Wait for the bulk action to complete
     let action = await contentfulClient.bulkAction.get({
@@ -78,19 +79,20 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
     
     // Create the bulk action
-    const bulkAction = await contentfulClient.bulkAction.unpublish({
-      spaceId,
-      environmentId,
-      action: "unpublish",
-      payload: {
+    const bulkAction = await contentfulClient.bulkAction.unpublish(
+      {
+        spaceId,
+        environmentId,
+      },
+      {
         entities: {
           sys: {
             type: "Array",
           },
           items: args.entities,
         },
-      },
-    })
+      }
+    )
     
     // Wait for the bulk action to complete
     let action = await contentfulClient.bulkAction.get({
@@ -129,11 +131,12 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
     
     // Create the bulk action
-    const bulkAction = await contentfulClient.bulkAction.validate({
-      spaceId,
-      environmentId,
-      action: "validate",
-      payload: {
+    const bulkAction = await contentfulClient.bulkAction.validate(
+      {
+        spaceId,
+        environmentId,
+      },
+      {
         entities: {
           sys: {
             type: "Array",
@@ -146,8 +149,8 @@ export const bulkActionHandlers = {
             }
           })),
         },
-      },
-    })
+      }
+    )
     
     // Wait for the bulk action to complete
     let action = await contentfulClient.bulkAction.get({

--- a/src/handlers/bulk-action-handlers.ts
+++ b/src/handlers/bulk-action-handlers.ts
@@ -1,0 +1,133 @@
+import { getContentfulClient } from "../config/client.js"
+
+type BulkPublishParams = {
+  spaceId: string
+  environmentId: string
+  entities: Array<{
+    sys: {
+      id: string
+      type: "Entry" | "Asset"
+    }
+  }>
+}
+
+type BulkUnpublishParams = BulkPublishParams
+
+type BulkValidateParams = {
+  spaceId: string
+  environmentId: string
+  entryIds: string[]
+}
+
+export const bulkActionHandlers = {
+  bulkPublish: async (args: BulkPublishParams) => {
+    const contentfulClient = await getContentfulClient()
+    const space = await contentfulClient.space.get({ spaceId: args.spaceId })
+    const environment = await space.getEnvironment(args.environmentId)
+    
+    const bulkAction = await environment.createPublishBulkAction({
+      entities: {
+        sys: {
+          type: "Array",
+        },
+        items: args.entities,
+      },
+    })
+    
+    // Wait for the bulk action to complete
+    let action = await bulkAction.get()
+    while (action.sys.status === "inProgress") {
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      action = await bulkAction.get()
+    }
+    
+    return {
+      content: [
+        { 
+          type: "text", 
+          text: `Bulk publish completed with status: ${action.sys.status}. ${
+            action.sys.status === "failed" 
+              ? `Error: ${JSON.stringify(action.error)}` 
+              : `Successfully processed ${action.succeeded?.length || 0} items.`
+          }`
+        }
+      ],
+    }
+  },
+  
+  bulkUnpublish: async (args: BulkUnpublishParams) => {
+    const contentfulClient = await getContentfulClient()
+    const space = await contentfulClient.space.get({ spaceId: args.spaceId })
+    const environment = await space.getEnvironment(args.environmentId)
+    
+    const bulkAction = await environment.createUnpublishBulkAction({
+      entities: {
+        sys: {
+          type: "Array",
+        },
+        items: args.entities,
+      },
+    })
+    
+    // Wait for the bulk action to complete
+    let action = await bulkAction.get()
+    while (action.sys.status === "inProgress") {
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      action = await bulkAction.get()
+    }
+    
+    return {
+      content: [
+        { 
+          type: "text", 
+          text: `Bulk unpublish completed with status: ${action.sys.status}. ${
+            action.sys.status === "failed" 
+              ? `Error: ${JSON.stringify(action.error)}` 
+              : `Successfully processed ${action.succeeded?.length || 0} items.`
+          }`
+        }
+      ],
+    }
+  },
+  
+  bulkValidate: async (args: BulkValidateParams) => {
+    const contentfulClient = await getContentfulClient()
+    const space = await contentfulClient.space.get({ spaceId: args.spaceId })
+    const environment = await space.getEnvironment(args.environmentId)
+    
+    const bulkAction = await environment.createValidateBulkAction({
+      entities: {
+        sys: {
+          type: "Array",
+        },
+        items: args.entryIds.map(id => ({
+          sys: {
+            type: "Link",
+            linkType: "Entry",
+            id
+          }
+        })),
+      },
+    })
+    
+    // Wait for the bulk action to complete
+    let action = await bulkAction.get()
+    while (action.sys.status === "inProgress") {
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      action = await bulkAction.get()
+    }
+    
+    return {
+      content: [
+        { 
+          type: "text", 
+          text: `Bulk validation completed with status: ${action.sys.status}. ${
+            action.sys.status === "failed" 
+              ? `Error: ${JSON.stringify(action.error)}` 
+              : `Successfully validated ${action.succeeded?.length || 0} entries.`
+          }`
+        }
+      ],
+    }
+  }
+}

--- a/src/handlers/bulk-action-handlers.ts
+++ b/src/handlers/bulk-action-handlers.ts
@@ -60,7 +60,7 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
 
     // Get the current version of each entity
-    const entityVersions = await Promise.all(
+    const entityVersions: VersionedLink[] = await Promise.all(
       args.entities.map(async (entity) => {
         try {
           // Get the current version of the entity
@@ -76,14 +76,17 @@ export const bulkActionHandlers = {
                 assetId: entity.sys.id
               });
           
-          return {
+          // Explicitly create a VersionedLink with the correct type
+          const versionedLink: VersionedLink = {
             sys: {
-              type: "Link",
+              type: "Link" as const,
               linkType: entity.sys.type as "Entry" | "Asset",
               id: entity.sys.id,
               version: currentEntity.sys.version
             }
           };
+          
+          return versionedLink;
         } catch (error) {
           console.error(`Error fetching entity ${entity.sys.id}: ${error}`);
           throw new Error(`Failed to get version for entity ${entity.sys.id}. All entities must have a version.`);
@@ -147,7 +150,7 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
 
     // Get the current version of each entity
-    const entityVersions = await Promise.all(
+    const entityVersions: VersionedLink[] = await Promise.all(
       args.entities.map(async (entity) => {
         try {
           // Get the current version of the entity
@@ -163,14 +166,17 @@ export const bulkActionHandlers = {
                 assetId: entity.sys.id
               });
           
-          return {
+          // Explicitly create a VersionedLink with the correct type
+          const versionedLink: VersionedLink = {
             sys: {
-              type: "Link",
+              type: "Link" as const,
               linkType: entity.sys.type as "Entry" | "Asset",
               id: entity.sys.id,
               version: currentEntity.sys.version
             }
           };
+          
+          return versionedLink;
         } catch (error) {
           console.error(`Error fetching entity ${entity.sys.id}: ${error}`);
           throw new Error(`Failed to get version for entity ${entity.sys.id}. All entities must have a version.`);
@@ -234,7 +240,7 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
 
     // Get the current version of each entry
-    const entityVersions = await Promise.all(
+    const entityVersions: VersionedLink[] = await Promise.all(
       args.entryIds.map(async (id) => {
         try {
           // Get the current version of the entry
@@ -244,14 +250,17 @@ export const bulkActionHandlers = {
             entryId: id
           });
           
-          return {
+          // Explicitly create a VersionedLink with the correct type
+          const versionedLink: VersionedLink = {
             sys: {
-              type: "Link",
+              type: "Link" as const,
               linkType: "Entry",
               id,
               version: currentEntry.sys.version
             }
           };
+          
+          return versionedLink;
         } catch (error) {
           console.error(`Error fetching entry ${id}: ${error}`);
           throw new Error(`Failed to get version for entry ${id}. All entries must have a version.`);

--- a/src/handlers/bulk-action-handlers.ts
+++ b/src/handlers/bulk-action-handlers.ts
@@ -32,8 +32,16 @@ interface VersionedLink {
     type: "Link"
     linkType: "Entry" | "Asset"
     id: string
-    version?: number
+    version: number
   }
+}
+
+// Define a Collection type to match SDK expectations
+interface Collection<T> {
+  sys: {
+    type: "Array"
+  }
+  items: T[]
 }
 
 type BulkUnpublishParams = BulkPublishParams
@@ -52,7 +60,7 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
 
     // Get the current version of each entity
-    const entityVersions: VersionedLink[] = await Promise.all(
+    const entityVersions = await Promise.all(
       args.entities.map(async (entity) => {
         try {
           // Get the current version of the entity
@@ -71,24 +79,25 @@ export const bulkActionHandlers = {
           return {
             sys: {
               type: "Link",
-              linkType: entity.sys.type,
+              linkType: entity.sys.type as "Entry" | "Asset",
               id: entity.sys.id,
               version: currentEntity.sys.version
             }
           };
         } catch (error) {
           console.error(`Error fetching entity ${entity.sys.id}: ${error}`);
-          // Return without version if we can't get it
-          return {
-            sys: {
-              type: "Link",
-              linkType: entity.sys.type,
-              id: entity.sys.id
-            }
-          };
+          throw new Error(`Failed to get version for entity ${entity.sys.id}. All entities must have a version.`);
         }
       })
     );
+
+    // Create the collection object with the correct structure
+    const entitiesCollection: Collection<VersionedLink> = {
+      sys: {
+        type: "Array"
+      },
+      items: entityVersions
+    };
 
     // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.publish(
@@ -97,12 +106,7 @@ export const bulkActionHandlers = {
         environmentId,
       },
       {
-        entities: {
-          sys: {
-            type: "Array",
-          },
-          items: entityVersions,
-        },
+        entities: entitiesCollection,
       },
     )
 
@@ -143,7 +147,7 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
 
     // Get the current version of each entity
-    const entityVersions: VersionedLink[] = await Promise.all(
+    const entityVersions = await Promise.all(
       args.entities.map(async (entity) => {
         try {
           // Get the current version of the entity
@@ -162,24 +166,25 @@ export const bulkActionHandlers = {
           return {
             sys: {
               type: "Link",
-              linkType: entity.sys.type,
+              linkType: entity.sys.type as "Entry" | "Asset",
               id: entity.sys.id,
               version: currentEntity.sys.version
             }
           };
         } catch (error) {
           console.error(`Error fetching entity ${entity.sys.id}: ${error}`);
-          // Return without version if we can't get it
-          return {
-            sys: {
-              type: "Link",
-              linkType: entity.sys.type,
-              id: entity.sys.id
-            }
-          };
+          throw new Error(`Failed to get version for entity ${entity.sys.id}. All entities must have a version.`);
         }
       })
     );
+
+    // Create the collection object with the correct structure
+    const entitiesCollection: Collection<VersionedLink> = {
+      sys: {
+        type: "Array"
+      },
+      items: entityVersions
+    };
 
     // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.unpublish(
@@ -188,12 +193,7 @@ export const bulkActionHandlers = {
         environmentId,
       },
       {
-        entities: {
-          sys: {
-            type: "Array",
-          },
-          items: entityVersions,
-        },
+        entities: entitiesCollection,
       },
     )
 
@@ -234,7 +234,7 @@ export const bulkActionHandlers = {
     const contentfulClient = await getContentfulClient()
 
     // Get the current version of each entry
-    const entityVersions: VersionedLink[] = await Promise.all(
+    const entityVersions = await Promise.all(
       args.entryIds.map(async (id) => {
         try {
           // Get the current version of the entry
@@ -254,17 +254,18 @@ export const bulkActionHandlers = {
           };
         } catch (error) {
           console.error(`Error fetching entry ${id}: ${error}`);
-          // Return without version if we can't get it
-          return {
-            sys: {
-              type: "Link",
-              linkType: "Entry",
-              id
-            }
-          };
+          throw new Error(`Failed to get version for entry ${id}. All entries must have a version.`);
         }
       })
     );
+
+    // Create the collection object with the correct structure
+    const entitiesCollection: Collection<VersionedLink> = {
+      sys: {
+        type: "Array"
+      },
+      items: entityVersions
+    };
 
     // Create the bulk action
     const bulkAction = await contentfulClient.bulkAction.validate(
@@ -273,12 +274,7 @@ export const bulkActionHandlers = {
         environmentId,
       },
       {
-        entities: {
-          sys: {
-            type: "Array",
-          },
-          items: entityVersions,
-        },
+        entities: entitiesCollection,
       },
     )
 

--- a/src/handlers/bulk-action-handlers.ts
+++ b/src/handlers/bulk-action-handlers.ts
@@ -21,24 +21,39 @@ type BulkValidateParams = {
 
 export const bulkActionHandlers = {
   bulkPublish: async (args: BulkPublishParams) => {
+    const spaceId = process.env.SPACE_ID || args.spaceId
+    const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
+
     const contentfulClient = await getContentfulClient()
-    const space = await contentfulClient.space.get({ spaceId: args.spaceId })
-    const environment = await space.getEnvironment(args.environmentId)
     
-    const bulkAction = await environment.createPublishBulkAction({
-      entities: {
-        sys: {
-          type: "Array",
+    // Create the bulk action
+    const bulkAction = await contentfulClient.environment.createPublishBulkAction({
+      spaceId,
+      environmentId,
+      payload: {
+        entities: {
+          sys: {
+            type: "Array",
+          },
+          items: args.entities,
         },
-        items: args.entities,
       },
     })
     
     // Wait for the bulk action to complete
-    let action = await bulkAction.get()
+    let action = await contentfulClient.bulkAction.get({
+      spaceId,
+      environmentId,
+      bulkActionId: bulkAction.sys.id
+    })
+    
     while (action.sys.status === "inProgress") {
       await new Promise(resolve => setTimeout(resolve, 1000))
-      action = await bulkAction.get()
+      action = await contentfulClient.bulkAction.get({
+        spaceId,
+        environmentId,
+        bulkActionId: bulkAction.sys.id
+      })
     }
     
     return {
@@ -56,24 +71,39 @@ export const bulkActionHandlers = {
   },
   
   bulkUnpublish: async (args: BulkUnpublishParams) => {
+    const spaceId = process.env.SPACE_ID || args.spaceId
+    const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
+
     const contentfulClient = await getContentfulClient()
-    const space = await contentfulClient.space.get({ spaceId: args.spaceId })
-    const environment = await space.getEnvironment(args.environmentId)
     
-    const bulkAction = await environment.createUnpublishBulkAction({
-      entities: {
-        sys: {
-          type: "Array",
+    // Create the bulk action
+    const bulkAction = await contentfulClient.environment.createUnpublishBulkAction({
+      spaceId,
+      environmentId,
+      payload: {
+        entities: {
+          sys: {
+            type: "Array",
+          },
+          items: args.entities,
         },
-        items: args.entities,
       },
     })
     
     // Wait for the bulk action to complete
-    let action = await bulkAction.get()
+    let action = await contentfulClient.bulkAction.get({
+      spaceId,
+      environmentId,
+      bulkActionId: bulkAction.sys.id
+    })
+    
     while (action.sys.status === "inProgress") {
       await new Promise(resolve => setTimeout(resolve, 1000))
-      action = await bulkAction.get()
+      action = await contentfulClient.bulkAction.get({
+        spaceId,
+        environmentId,
+        bulkActionId: bulkAction.sys.id
+      })
     }
     
     return {
@@ -91,30 +121,45 @@ export const bulkActionHandlers = {
   },
   
   bulkValidate: async (args: BulkValidateParams) => {
+    const spaceId = process.env.SPACE_ID || args.spaceId
+    const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
+
     const contentfulClient = await getContentfulClient()
-    const space = await contentfulClient.space.get({ spaceId: args.spaceId })
-    const environment = await space.getEnvironment(args.environmentId)
     
-    const bulkAction = await environment.createValidateBulkAction({
-      entities: {
-        sys: {
-          type: "Array",
-        },
-        items: args.entryIds.map(id => ({
+    // Create the bulk action
+    const bulkAction = await contentfulClient.environment.createValidateBulkAction({
+      spaceId,
+      environmentId,
+      payload: {
+        entities: {
           sys: {
-            type: "Link",
-            linkType: "Entry",
-            id
-          }
-        })),
+            type: "Array",
+          },
+          items: args.entryIds.map(id => ({
+            sys: {
+              type: "Link",
+              linkType: "Entry",
+              id
+            }
+          })),
+        },
       },
     })
     
     // Wait for the bulk action to complete
-    let action = await bulkAction.get()
+    let action = await contentfulClient.bulkAction.get({
+      spaceId,
+      environmentId,
+      bulkActionId: bulkAction.sys.id
+    })
+    
     while (action.sys.status === "inProgress") {
       await new Promise(resolve => setTimeout(resolve, 1000))
-      action = await bulkAction.get()
+      action = await contentfulClient.bulkAction.get({
+        spaceId,
+        environmentId,
+        bulkActionId: bulkAction.sys.id
+      })
     }
     
     return {

--- a/src/handlers/entry-handlers.ts
+++ b/src/handlers/entry-handlers.ts
@@ -121,10 +121,31 @@ export const entryHandlers = {
     }
   },
 
-  publishEntry: async (args: { spaceId: string; environmentId: string; entryId: string }) => {
+  publishEntry: async (args: { 
+    spaceId: string; 
+    environmentId: string; 
+    entryId: string | string[] 
+  }) => {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
 
+    // If entryId is an array, use bulkPublish instead
+    if (Array.isArray(args.entryId)) {
+      const bulkActionHandlers = await import("./bulk-action-handlers.js").then(module => module.bulkActionHandlers)
+      
+      // Map entry IDs to the expected format for bulkPublish
+      const entities = args.entryId.map(id => ({
+        sys: { id, type: "Entry" as const }
+      }))
+      
+      return bulkActionHandlers.bulkPublish({
+        spaceId,
+        environmentId,
+        entities
+      })
+    }
+    
+    // Handle single entry publishing
     const params = {
       spaceId,
       environmentId,
@@ -138,15 +159,37 @@ export const entryHandlers = {
       sys: currentEntry.sys,
       fields: currentEntry.fields,
     })
+    
     return {
       content: [{ type: "text", text: JSON.stringify(entry, null, 2) }],
     }
   },
 
-  unpublishEntry: async (args: { spaceId: string; environmentId: string; entryId: string }) => {
+  unpublishEntry: async (args: { 
+    spaceId: string; 
+    environmentId: string; 
+    entryId: string | string[] 
+  }) => {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
 
+    // If entryId is an array, use bulkUnpublish instead
+    if (Array.isArray(args.entryId)) {
+      const bulkActionHandlers = await import("./bulk-action-handlers.js").then(module => module.bulkActionHandlers)
+      
+      // Map entry IDs to the expected format for bulkUnpublish
+      const entities = args.entryId.map(id => ({
+        sys: { id, type: "Entry" as const }
+      }))
+      
+      return bulkActionHandlers.bulkUnpublish({
+        spaceId,
+        environmentId,
+        entities
+      })
+    }
+    
+    // Handle single entry unpublishing
     const params = {
       spaceId,
       environmentId,

--- a/src/handlers/space-handlers.ts
+++ b/src/handlers/space-handlers.ts
@@ -33,19 +33,15 @@ export const spaceHandlers = {
   },
 
   createEnvironment: async (args: { spaceId: string; environmentId: string; name: string }) => {
-    const params = {
-      spaceId: args.spaceId,
-    }
-
-    const environmentProps = {
-      name: args.name,
-    }
-
     const contentfulClient = await getContentfulClient()
     const environment = await contentfulClient.environment.create(
-      params,
-      args.environmentId,
-      environmentProps,
+      {
+        spaceId: args.spaceId,
+        environmentId: args.environmentId,
+      },
+      {
+        name: args.name,
+      },
     )
     return {
       content: [{ type: "text", text: JSON.stringify(environment, null, 2) }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { entryHandlers } from "./handlers/entry-handlers.js"
 import { assetHandlers } from "./handlers/asset-handlers.js"
 import { spaceHandlers } from "./handlers/space-handlers.js"
 import { contentTypeHandlers } from "./handlers/content-type-handlers.js"
+import { bulkActionHandlers } from "./handlers/bulk-action-handlers.js"
 import { getTools } from "./types/tools.js"
 import { validateEnvironment } from "./utils/validation.js"
 
@@ -83,6 +84,11 @@ function getHandler(name: string) {
     publish_entry: entryHandlers.publishEntry,
     unpublish_entry: entryHandlers.unpublishEntry,
     search_entries: entryHandlers.searchEntries,
+    
+    // Bulk operations
+    bulk_publish: bulkActionHandlers.bulkPublish,
+    bulk_unpublish: bulkActionHandlers.bulkUnpublish,
+    bulk_validate: bulkActionHandlers.bulkValidate,
 
     // Asset operations
     upload_asset: assetHandlers.uploadAsset,

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -497,6 +497,99 @@ export const getSpaceEnvTools = () => {
   }
 }
 
+// Tool definitions for Bulk Actions
+export const getBulkActionTools = () => {
+  return {
+    BULK_PUBLISH: {
+      name: "bulk_publish",
+      description: "Publish multiple entries or assets at once",
+      inputSchema: getSpaceEnvProperties({
+        type: "object",
+        properties: {
+          entities: {
+            type: "array",
+            description: "Array of entries or assets to publish",
+            items: {
+              type: "object",
+              properties: {
+                sys: {
+                  type: "object",
+                  properties: {
+                    id: { 
+                      type: "string",
+                      description: "ID of the entry or asset"
+                    },
+                    type: { 
+                      type: "string",
+                      enum: ["Entry", "Asset"],
+                      description: "Type of entity (Entry or Asset)"
+                    }
+                  },
+                  required: ["id", "type"]
+                }
+              },
+              required: ["sys"]
+            }
+          }
+        },
+        required: ["entities"]
+      })
+    },
+    BULK_UNPUBLISH: {
+      name: "bulk_unpublish",
+      description: "Unpublish multiple entries or assets at once",
+      inputSchema: getSpaceEnvProperties({
+        type: "object",
+        properties: {
+          entities: {
+            type: "array",
+            description: "Array of entries or assets to unpublish",
+            items: {
+              type: "object",
+              properties: {
+                sys: {
+                  type: "object",
+                  properties: {
+                    id: { 
+                      type: "string",
+                      description: "ID of the entry or asset"
+                    },
+                    type: { 
+                      type: "string",
+                      enum: ["Entry", "Asset"],
+                      description: "Type of entity (Entry or Asset)"
+                    }
+                  },
+                  required: ["id", "type"]
+                }
+              },
+              required: ["sys"]
+            }
+          }
+        },
+        required: ["entities"]
+      })
+    },
+    BULK_VALIDATE: {
+      name: "bulk_validate",
+      description: "Validate multiple entries at once",
+      inputSchema: getSpaceEnvProperties({
+        type: "object",
+        properties: {
+          entryIds: {
+            type: "array",
+            description: "Array of entry IDs to validate",
+            items: {
+              type: "string"
+            }
+          }
+        },
+        required: ["entryIds"]
+      })
+    }
+  }
+}
+
 // Export combined tools
 export const getTools = () => {
   return {
@@ -504,5 +597,6 @@ export const getTools = () => {
     ...getAssetTools(),
     ...getContentTypeTools(),
     ...getSpaceEnvTools(),
+    ...getBulkActionTools(),
   }
 }

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -124,22 +124,46 @@ export const getEntryTools = () => {
     },
     PUBLISH_ENTRY: {
       name: "publish_entry",
-      description: "Publish an entry",
+      description:
+        "Publish an entry or multiple entries. Accepts either a single entryId (string) or an array of entryIds (up to 100 entries). For a single entry, it uses the standard publish operation. For multiple entries, it automatically uses bulk publishing.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
-          entryId: { type: "string" },
+          entryId: { 
+            oneOf: [
+              { type: "string" },
+              { 
+                type: "array", 
+                items: { type: "string" },
+                maxItems: 100,
+                description: "Array of entry IDs to publish (max: 100)"
+              }
+            ],
+            description: "ID of the entry to publish, or an array of entry IDs (max: 100)"
+          },
         },
         required: ["entryId"],
       }),
     },
     UNPUBLISH_ENTRY: {
       name: "unpublish_entry",
-      description: "Unpublish an entry",
+      description:
+        "Unpublish an entry or multiple entries. Accepts either a single entryId (string) or an array of entryIds (up to 100 entries). For a single entry, it uses the standard unpublish operation. For multiple entries, it automatically uses bulk unpublishing.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
-          entryId: { type: "string" },
+          entryId: { 
+            oneOf: [
+              { type: "string" },
+              { 
+                type: "array", 
+                items: { type: "string" },
+                maxItems: 100,
+                description: "Array of entry IDs to unpublish (max: 100)"
+              }
+            ],
+            description: "ID of the entry to unpublish, or an array of entry IDs (max: 100)"
+          },
         },
         required: ["entryId"],
       }),
@@ -515,25 +539,25 @@ export const getBulkActionTools = () => {
                 sys: {
                   type: "object",
                   properties: {
-                    id: { 
+                    id: {
                       type: "string",
-                      description: "ID of the entry or asset"
+                      description: "ID of the entry or asset",
                     },
-                    type: { 
+                    type: {
                       type: "string",
                       enum: ["Entry", "Asset"],
-                      description: "Type of entity (Entry or Asset)"
-                    }
+                      description: "Type of entity (Entry or Asset)",
+                    },
                   },
-                  required: ["id", "type"]
-                }
+                  required: ["id", "type"],
+                },
               },
-              required: ["sys"]
-            }
-          }
+              required: ["sys"],
+            },
+          },
         },
-        required: ["entities"]
-      })
+        required: ["entities"],
+      }),
     },
     BULK_UNPUBLISH: {
       name: "bulk_unpublish",
@@ -550,25 +574,25 @@ export const getBulkActionTools = () => {
                 sys: {
                   type: "object",
                   properties: {
-                    id: { 
+                    id: {
                       type: "string",
-                      description: "ID of the entry or asset"
+                      description: "ID of the entry or asset",
                     },
-                    type: { 
+                    type: {
                       type: "string",
                       enum: ["Entry", "Asset"],
-                      description: "Type of entity (Entry or Asset)"
-                    }
+                      description: "Type of entity (Entry or Asset)",
+                    },
                   },
-                  required: ["id", "type"]
-                }
+                  required: ["id", "type"],
+                },
               },
-              required: ["sys"]
-            }
-          }
+              required: ["sys"],
+            },
+          },
         },
-        required: ["entities"]
-      })
+        required: ["entities"],
+      }),
     },
     BULK_VALIDATE: {
       name: "bulk_validate",
@@ -580,13 +604,13 @@ export const getBulkActionTools = () => {
             type: "array",
             description: "Array of entry IDs to validate",
             items: {
-              type: "string"
-            }
-          }
+              type: "string",
+            },
+          },
         },
-        required: ["entryIds"]
-      })
-    }
+        required: ["entryIds"],
+      }),
+    },
   }
 }
 

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1,4 +1,12 @@
-export const getSpaceEnvProperties = (config) => {
+// Define interface for config parameter
+interface ConfigSchema {
+  type: string
+  properties: Record<string, any>
+  required?: string[]
+  [key: string]: any
+}
+
+export const getSpaceEnvProperties = (config: ConfigSchema): ConfigSchema => {
   const spaceEnvProperties = {
     spaceId: {
       type: "string",

--- a/test/integration/bulk-action-handler.test.ts
+++ b/test/integration/bulk-action-handler.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from "vitest"
+import { expect } from "vitest"
 import { bulkActionHandlers } from "../../src/handlers/bulk-action-handlers.js"
 import { server } from "../msw-setup.js"
 

--- a/test/integration/bulk-action-handler.test.ts
+++ b/test/integration/bulk-action-handler.test.ts
@@ -1,51 +1,51 @@
-import { expect } from "vitest";
-import { bulkActionHandlers } from "../../src/handlers/bulk-action-handlers.js";
-import { server } from "../msw-setup.js";
+import { expect, vi } from "vitest"
+import { bulkActionHandlers } from "../../src/handlers/bulk-action-handlers.js"
+import { server } from "../msw-setup.js"
 
 describe("Bulk Action Handlers Integration Tests", () => {
   // Start MSW Server before tests
-  beforeAll(() => server.listen());
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
 
-  const testSpaceId = "test-space-id";
-  const testEnvironmentId = "master";
-  const testEntryId = "test-entry-id";
-  const testAssetId = "test-asset-id";
+  const testSpaceId = "test-space-id"
+  const testEnvironmentId = "master"
+  const testEntryId = "test-entry-id"
+  const testAssetId = "test-asset-id"
 
   // Mock the getContentfulClient function to avoid actual API calls
   vi.mock("../../src/config/client.js", () => ({
     getContentfulClient: vi.fn().mockResolvedValue({
       entry: {
         get: vi.fn().mockResolvedValue({
-          sys: { id: testEntryId, version: 1 }
-        })
+          sys: { id: testEntryId, version: 1 },
+        }),
       },
       asset: {
         get: vi.fn().mockResolvedValue({
-          sys: { id: testAssetId, version: 1 }
-        })
+          sys: { id: testAssetId, version: 1 },
+        }),
       },
       bulkAction: {
         publish: vi.fn().mockResolvedValue({
-          sys: { id: "test-bulk-action-id", status: "created" }
+          sys: { id: "test-bulk-action-id", status: "created" },
         }),
         unpublish: vi.fn().mockResolvedValue({
-          sys: { id: "test-bulk-action-id", status: "created" }
+          sys: { id: "test-bulk-action-id", status: "created" },
         }),
         validate: vi.fn().mockResolvedValue({
-          sys: { id: "test-bulk-action-id", status: "created" }
+          sys: { id: "test-bulk-action-id", status: "created" },
         }),
         get: vi.fn().mockResolvedValue({
           sys: { id: "test-bulk-action-id", status: "succeeded" },
           succeeded: [
             { sys: { id: testEntryId, type: "Entry" } },
-            { sys: { id: testAssetId, type: "Asset" } }
-          ]
-        })
-      }
-    })
-  }));
+            { sys: { id: testAssetId, type: "Asset" } },
+          ],
+        }),
+      },
+    }),
+  }))
 
   describe("bulkPublish", () => {
     it("should publish multiple entries and assets", async () => {
@@ -54,15 +54,15 @@ describe("Bulk Action Handlers Integration Tests", () => {
         environmentId: testEnvironmentId,
         entities: [
           { sys: { id: testEntryId, type: "Entry" } },
-          { sys: { id: testAssetId, type: "Asset" } }
-        ]
-      });
+          { sys: { id: testAssetId, type: "Asset" } },
+        ],
+      })
 
-      expect(result).to.have.property("content").that.is.an("array");
-      expect(result.content[0].text).to.include("Bulk publish completed");
-      expect(result.content[0].text).to.include("Successfully processed");
-    });
-  });
+      expect(result).to.have.property("content").that.is.an("array")
+      expect(result.content[0].text).to.include("Bulk publish completed")
+      expect(result.content[0].text).to.include("Successfully processed")
+    })
+  })
 
   describe("bulkUnpublish", () => {
     it("should unpublish multiple entries and assets", async () => {
@@ -71,27 +71,27 @@ describe("Bulk Action Handlers Integration Tests", () => {
         environmentId: testEnvironmentId,
         entities: [
           { sys: { id: testEntryId, type: "Entry" } },
-          { sys: { id: testAssetId, type: "Asset" } }
-        ]
-      });
+          { sys: { id: testAssetId, type: "Asset" } },
+        ],
+      })
 
-      expect(result).to.have.property("content").that.is.an("array");
-      expect(result.content[0].text).to.include("Bulk unpublish completed");
-      expect(result.content[0].text).to.include("Successfully processed");
-    });
-  });
+      expect(result).to.have.property("content").that.is.an("array")
+      expect(result.content[0].text).to.include("Bulk unpublish completed")
+      expect(result.content[0].text).to.include("Successfully processed")
+    })
+  })
 
   describe("bulkValidate", () => {
     it("should validate multiple entries", async () => {
       const result = await bulkActionHandlers.bulkValidate({
         spaceId: testSpaceId,
         environmentId: testEnvironmentId,
-        entryIds: [testEntryId]
-      });
+        entryIds: [testEntryId],
+      })
 
-      expect(result).to.have.property("content").that.is.an("array");
-      expect(result.content[0].text).to.include("Bulk validation completed");
-      expect(result.content[0].text).to.include("Successfully validated");
-    });
-  });
-});
+      expect(result).to.have.property("content").that.is.an("array")
+      expect(result.content[0].text).to.include("Bulk validation completed")
+      expect(result.content[0].text).to.include("Successfully validated")
+    })
+  })
+})

--- a/test/integration/bulk-action-handler.test.ts
+++ b/test/integration/bulk-action-handler.test.ts
@@ -1,50 +1,49 @@
 import { expect, vi } from "vitest"
 import { server } from "../msw-setup.js"
 
-// Define mock values
+// Define mock values first - these can be before vi.mock
 const TEST_ENTRY_ID = "test-entry-id"
 const TEST_ASSET_ID = "test-asset-id"
 const TEST_BULK_ACTION_ID = "test-bulk-action-id"
 
-// Create mock implementation
-const mockClient = {
-  entry: {
-    get: vi.fn().mockResolvedValue({
-      sys: { id: TEST_ENTRY_ID, version: 1 },
+// Mock the client module without using variables defined later
+vi.mock("../../src/config/client.ts", () => {
+  return {
+    getContentfulClient: vi.fn().mockResolvedValue({
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: { id: "test-entry-id", version: 1 },
+        }),
+      },
+      asset: {
+        get: vi.fn().mockResolvedValue({
+          sys: { id: "test-asset-id", version: 1 },
+        }),
+      },
+      bulkAction: {
+        publish: vi.fn().mockResolvedValue({
+          sys: { id: "test-bulk-action-id", status: "created" },
+        }),
+        unpublish: vi.fn().mockResolvedValue({
+          sys: { id: "test-bulk-action-id", status: "created" },
+        }),
+        validate: vi.fn().mockResolvedValue({
+          sys: { id: "test-bulk-action-id", status: "created" },
+        }),
+        get: vi.fn().mockResolvedValue({
+          sys: { id: "test-bulk-action-id", status: "succeeded" },
+          succeeded: [
+            { sys: { id: "test-entry-id", type: "Entry" } },
+            { sys: { id: "test-asset-id", type: "Asset" } },
+          ],
+        }),
+      },
     }),
-  },
-  asset: {
-    get: vi.fn().mockResolvedValue({
-      sys: { id: TEST_ASSET_ID, version: 1 },
-    }),
-  },
-  bulkAction: {
-    publish: vi.fn().mockResolvedValue({
-      sys: { id: TEST_BULK_ACTION_ID, status: "created" },
-    }),
-    unpublish: vi.fn().mockResolvedValue({
-      sys: { id: TEST_BULK_ACTION_ID, status: "created" },
-    }),
-    validate: vi.fn().mockResolvedValue({
-      sys: { id: TEST_BULK_ACTION_ID, status: "created" },
-    }),
-    get: vi.fn().mockResolvedValue({
-      sys: { id: TEST_BULK_ACTION_ID, status: "succeeded" },
-      succeeded: [
-        { sys: { id: TEST_ENTRY_ID, type: "Entry" } },
-        { sys: { id: TEST_ASSET_ID, type: "Asset" } },
-      ],
-    }),
-  },
-}
-
-// Mock the client module
-vi.mock("../../src/config/client.js", () => ({
-  getContentfulClient: vi.fn().mockResolvedValue(mockClient)
-}))
+  }
+})
 
 // Import handlers after mocking
-import { bulkActionHandlers } from "../../src/handlers/bulk-action-handlers.js"
+import { bulkActionHandlers } from "../../src/handlers/bulk-action-handlers.ts"
 
 describe("Bulk Action Handlers Integration Tests", () => {
   // Start MSW Server before tests
@@ -61,8 +60,8 @@ describe("Bulk Action Handlers Integration Tests", () => {
         spaceId: testSpaceId,
         environmentId: testEnvironmentId,
         entities: [
-          { sys: { id: testEntryId, type: "Entry" } },
-          { sys: { id: testAssetId, type: "Asset" } },
+          { sys: { id: TEST_ENTRY_ID, type: "Entry" } },
+          { sys: { id: TEST_ASSET_ID, type: "Asset" } },
         ],
       })
 
@@ -78,8 +77,8 @@ describe("Bulk Action Handlers Integration Tests", () => {
         spaceId: testSpaceId,
         environmentId: testEnvironmentId,
         entities: [
-          { sys: { id: testEntryId, type: "Entry" } },
-          { sys: { id: testAssetId, type: "Asset" } },
+          { sys: { id: TEST_ENTRY_ID, type: "Entry" } },
+          { sys: { id: TEST_ASSET_ID, type: "Asset" } },
         ],
       })
 
@@ -94,7 +93,7 @@ describe("Bulk Action Handlers Integration Tests", () => {
       const result = await bulkActionHandlers.bulkValidate({
         spaceId: testSpaceId,
         environmentId: testEnvironmentId,
-        entryIds: [testEntryId],
+        entryIds: [TEST_ENTRY_ID],
       })
 
       expect(result).to.have.property("content").that.is.an("array")

--- a/test/integration/bulk-action-handler.test.ts
+++ b/test/integration/bulk-action-handler.test.ts
@@ -1,0 +1,97 @@
+import { expect } from "vitest";
+import { bulkActionHandlers } from "../../src/handlers/bulk-action-handlers.js";
+import { server } from "../msw-setup.js";
+
+describe("Bulk Action Handlers Integration Tests", () => {
+  // Start MSW Server before tests
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  const testSpaceId = "test-space-id";
+  const testEnvironmentId = "master";
+  const testEntryId = "test-entry-id";
+  const testAssetId = "test-asset-id";
+
+  // Mock the getContentfulClient function to avoid actual API calls
+  vi.mock("../../src/config/client.js", () => ({
+    getContentfulClient: vi.fn().mockResolvedValue({
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: { id: testEntryId, version: 1 }
+        })
+      },
+      asset: {
+        get: vi.fn().mockResolvedValue({
+          sys: { id: testAssetId, version: 1 }
+        })
+      },
+      bulkAction: {
+        publish: vi.fn().mockResolvedValue({
+          sys: { id: "test-bulk-action-id", status: "created" }
+        }),
+        unpublish: vi.fn().mockResolvedValue({
+          sys: { id: "test-bulk-action-id", status: "created" }
+        }),
+        validate: vi.fn().mockResolvedValue({
+          sys: { id: "test-bulk-action-id", status: "created" }
+        }),
+        get: vi.fn().mockResolvedValue({
+          sys: { id: "test-bulk-action-id", status: "succeeded" },
+          succeeded: [
+            { sys: { id: testEntryId, type: "Entry" } },
+            { sys: { id: testAssetId, type: "Asset" } }
+          ]
+        })
+      }
+    })
+  }));
+
+  describe("bulkPublish", () => {
+    it("should publish multiple entries and assets", async () => {
+      const result = await bulkActionHandlers.bulkPublish({
+        spaceId: testSpaceId,
+        environmentId: testEnvironmentId,
+        entities: [
+          { sys: { id: testEntryId, type: "Entry" } },
+          { sys: { id: testAssetId, type: "Asset" } }
+        ]
+      });
+
+      expect(result).to.have.property("content").that.is.an("array");
+      expect(result.content[0].text).to.include("Bulk publish completed");
+      expect(result.content[0].text).to.include("Successfully processed");
+    });
+  });
+
+  describe("bulkUnpublish", () => {
+    it("should unpublish multiple entries and assets", async () => {
+      const result = await bulkActionHandlers.bulkUnpublish({
+        spaceId: testSpaceId,
+        environmentId: testEnvironmentId,
+        entities: [
+          { sys: { id: testEntryId, type: "Entry" } },
+          { sys: { id: testAssetId, type: "Asset" } }
+        ]
+      });
+
+      expect(result).to.have.property("content").that.is.an("array");
+      expect(result.content[0].text).to.include("Bulk unpublish completed");
+      expect(result.content[0].text).to.include("Successfully processed");
+    });
+  });
+
+  describe("bulkValidate", () => {
+    it("should validate multiple entries", async () => {
+      const result = await bulkActionHandlers.bulkValidate({
+        spaceId: testSpaceId,
+        environmentId: testEnvironmentId,
+        entryIds: [testEntryId]
+      });
+
+      expect(result).to.have.property("content").that.is.an("array");
+      expect(result.content[0].text).to.include("Bulk validation completed");
+      expect(result.content[0].text).to.include("Successfully validated");
+    });
+  });
+});

--- a/test/integration/entry-handler.test.ts
+++ b/test/integration/entry-handler.test.ts
@@ -1,61 +1,88 @@
-import { expect } from "vitest";
-import { entryHandlers } from "../../src/handlers/entry-handlers.js";
-import { server } from "../msw-setup.js";
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import { expect, vi } from "vitest"
+import { entryHandlers } from "../../src/handlers/entry-handlers.js"
+import { server } from "../msw-setup.js"
+
+// Set up mocks for bulk action handlers
+const bulkPublishMock = vi.fn().mockResolvedValue({
+  content: [
+    {
+      type: "text",
+      text: "Bulk publish completed with status: succeeded. Successfully processed 2 items.",
+    },
+  ],
+})
+
+const bulkUnpublishMock = vi.fn().mockResolvedValue({
+  content: [
+    {
+      type: "text",
+      text: "Bulk unpublish completed with status: succeeded. Successfully processed 2 items.",
+    },
+  ],
+})
+
+vi.mock("../../src/handlers/bulk-action-handlers.js", () => ({
+  bulkActionHandlers: {
+    bulkPublish: bulkPublishMock,
+    bulkUnpublish: bulkUnpublishMock,
+  },
+}))
 
 describe("Entry Handlers Integration Tests", () => {
   // Start MSW Server before tests
-  beforeAll(() => server.listen());
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
 
-  const testSpaceId = "test-space-id";
-  const testEntryId = "test-entry-id";
-  const testContentTypeId = "test-content-type-id";
+  const testSpaceId = "test-space-id"
+  const testEntryId = "test-entry-id"
+  const testContentTypeId = "test-content-type-id"
 
   describe("searchEntries", () => {
     it("should search all entries", async () => {
       const result = await entryHandlers.searchEntries({
         spaceId: testSpaceId,
         query: {
-          content_type: testContentTypeId
-        }
-      });
+          content_type: testContentTypeId,
+        },
+      })
 
-      expect(result).to.have.property("content").that.is.an("array");
-      expect(result.content).to.have.lengthOf(1);
-      
-      const entries = JSON.parse(result.content[0].text);
-      expect(entries.items).to.be.an("array");
-      expect(entries.items[0]).to.have.nested.property("sys.id", "test-entry-id");
-      expect(entries.items[0]).to.have.nested.property("fields.title.en-US", "Test Entry");
-    });
-  });
+      expect(result).to.have.property("content").that.is.an("array")
+      expect(result.content).to.have.lengthOf(1)
+
+      const entries = JSON.parse(result.content[0].text)
+      expect(entries.items).to.be.an("array")
+      expect(entries.items[0]).to.have.nested.property("sys.id", "test-entry-id")
+      expect(entries.items[0]).to.have.nested.property("fields.title.en-US", "Test Entry")
+    })
+  })
 
   describe("getEntry", () => {
     it("should get details of a specific entry", async () => {
       const result = await entryHandlers.getEntry({
         spaceId: testSpaceId,
-        entryId: testEntryId
-      });
+        entryId: testEntryId,
+      })
 
-      expect(result).to.have.property("content");
-      const entry = JSON.parse(result.content[0].text);
-      expect(entry.sys.id).to.equal(testEntryId);
-      expect(entry).to.have.nested.property("fields.title.en-US", "Test Entry");
-    });
+      expect(result).to.have.property("content")
+      const entry = JSON.parse(result.content[0].text)
+      expect(entry.sys.id).to.equal(testEntryId)
+      expect(entry).to.have.nested.property("fields.title.en-US", "Test Entry")
+    })
 
     it("should throw error for invalid entry ID", async () => {
       try {
         await entryHandlers.getEntry({
           spaceId: testSpaceId,
-          entryId: "invalid-entry-id"
-        });
-        expect.fail("Should have thrown an error");
+          entryId: "invalid-entry-id",
+        })
+        expect.fail("Should have thrown an error")
       } catch (error) {
-        expect(error).to.exist;
+        expect(error).to.exist
       }
-    });
-  });
+    })
+  })
 
   describe("createEntry", () => {
     it("should create a new entry", async () => {
@@ -64,18 +91,18 @@ describe("Entry Handlers Integration Tests", () => {
         contentTypeId: testContentTypeId,
         fields: {
           title: { "en-US": "New Entry" },
-          description: { "en-US": "New Description" }
-        }
-      };
+          description: { "en-US": "New Description" },
+        },
+      }
 
-      const result = await entryHandlers.createEntry(entryData);
+      const result = await entryHandlers.createEntry(entryData)
 
-      expect(result).to.have.property("content");
-      const entry = JSON.parse(result.content[0].text);
-      expect(entry).to.have.nested.property("sys.id", "new-entry-id");
-      expect(entry).to.have.nested.property("fields.title.en-US", "New Entry");
-    });
-  });
+      expect(result).to.have.property("content")
+      const entry = JSON.parse(result.content[0].text)
+      expect(entry).to.have.nested.property("sys.id", "new-entry-id")
+      expect(entry).to.have.nested.property("fields.title.en-US", "New Entry")
+    })
+  })
 
   describe("updateEntry", () => {
     it("should update an existing entry", async () => {
@@ -84,66 +111,114 @@ describe("Entry Handlers Integration Tests", () => {
         entryId: testEntryId,
         fields: {
           title: { "en-US": "Updated Entry" },
-          description: { "en-US": "Updated Description" }
-        }
-      };
+          description: { "en-US": "Updated Description" },
+        },
+      }
 
-      const result = await entryHandlers.updateEntry(updateData);
+      const result = await entryHandlers.updateEntry(updateData)
 
-      expect(result).to.have.property("content");
-      const entry = JSON.parse(result.content[0].text);
-      expect(entry.sys.id).to.equal(testEntryId);
-      expect(entry).to.have.nested.property("fields.title.en-US", "Updated Entry");
-    });
-  });
+      expect(result).to.have.property("content")
+      const entry = JSON.parse(result.content[0].text)
+      expect(entry.sys.id).to.equal(testEntryId)
+      expect(entry).to.have.nested.property("fields.title.en-US", "Updated Entry")
+    })
+  })
 
   describe("deleteEntry", () => {
     it("should delete an entry", async () => {
       const result = await entryHandlers.deleteEntry({
         spaceId: testSpaceId,
-        entryId: testEntryId
-      });
+        entryId: testEntryId,
+      })
 
-      expect(result).to.have.property("content");
-      expect(result.content[0].text).to.include("deleted successfully");
-    });
+      expect(result).to.have.property("content")
+      expect(result.content[0].text).to.include("deleted successfully")
+    })
 
     it("should throw error when deleting non-existent entry", async () => {
       try {
         await entryHandlers.deleteEntry({
           spaceId: testSpaceId,
-          entryId: "non-existent-id"
-        });
-        expect.fail("Should have thrown an error");
+          entryId: "non-existent-id",
+        })
+        expect.fail("Should have thrown an error")
       } catch (error) {
-        expect(error).to.exist;
+        expect(error).to.exist
       }
-    });
-  });
+    })
+  })
 
   describe("publishEntry", () => {
-    it("should publish an entry", async () => {
+    it("should publish a single entry", async () => {
       const result = await entryHandlers.publishEntry({
         spaceId: testSpaceId,
-        entryId: testEntryId
-      });
+        entryId: testEntryId,
+      })
 
-      expect(result).to.have.property("content");
-      const entry = JSON.parse(result.content[0].text);
-      expect(entry.sys.publishedVersion).to.exist;
-    });
-  });
+      expect(result).to.have.property("content")
+      const entry = JSON.parse(result.content[0].text)
+      expect(entry.sys.publishedVersion).to.exist
+    })
+
+    it("should publish multiple entries using bulkPublish", async () => {
+      // Clear previous calls to the mock
+      bulkPublishMock.mockClear()
+
+      const result = await entryHandlers.publishEntry({
+        spaceId: testSpaceId,
+        entryId: ["entry-id-1", "entry-id-2"],
+      })
+
+      expect(bulkPublishMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spaceId: testSpaceId,
+          entities: [
+            { sys: { id: "entry-id-1", type: "Entry" } },
+            { sys: { id: "entry-id-2", type: "Entry" } },
+          ],
+        }),
+      )
+
+      expect(result).to.have.property("content")
+      expect(result.content[0].text).to.include("Bulk publish completed")
+      expect(result.content[0].text).to.include("Successfully processed")
+    })
+  })
 
   describe("unpublishEntry", () => {
-    it("should unpublish an entry", async () => {
+    it("should unpublish a single entry", async () => {
       const result = await entryHandlers.unpublishEntry({
         spaceId: testSpaceId,
-        entryId: testEntryId
-      });
+        entryId: testEntryId,
+      })
 
-      expect(result).to.have.property("content");
-      const entry = JSON.parse(result.content[0].text);
-      expect(entry.sys.publishedVersion).to.not.exist;
-    });
-  });
-});
+      expect(result).to.have.property("content")
+      const entry = JSON.parse(result.content[0].text)
+      expect(entry.sys.publishedVersion).to.not.exist
+    })
+
+    it("should unpublish multiple entries using bulkUnpublish", async () => {
+      // Clear previous calls to the mock
+      bulkUnpublishMock.mockClear()
+
+      const result = await entryHandlers.unpublishEntry({
+        spaceId: testSpaceId,
+        entryId: ["entry-id-1", "entry-id-2"],
+      })
+
+      expect(bulkUnpublishMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spaceId: testSpaceId,
+          entities: [
+            { sys: { id: "entry-id-1", type: "Entry" } },
+            { sys: { id: "entry-id-2", type: "Entry" } },
+          ],
+        }),
+      )
+
+      expect(result).to.have.property("content")
+      expect(result.content[0].text).to.include("Bulk unpublish completed")
+      expect(result.content[0].text).to.include("Successfully processed")
+    })
+  })
+})

--- a/test/msw-setup.ts
+++ b/test/msw-setup.ts
@@ -65,11 +65,25 @@ export const handlers = [
     async ({ params, request }) => {
       const { spaceId } = params;
       if (spaceId === "test-space-id") {
-        const envId = await request.text();
-        return HttpResponse.json({
-          sys: { id: envId },
-          name: envId,
-        });
+        try {
+          // Get data from request body
+          const body = await request.json();
+          console.log("Request body:", JSON.stringify(body));
+          
+          // In the real API implementation, the environmentId is taken 
+          // from the second argument to client.environment.create
+          // We need to extract it from the name in our mock
+          const environmentId = body.name;
+          
+          // Return correctly structured response with environment ID
+          return HttpResponse.json({
+            sys: { id: environmentId },
+            name: environmentId
+          });
+        } catch (error) {
+          console.error("Error processing environment creation:", error);
+          return new HttpResponse(null, { status: 500 });
+        }
       }
       return new HttpResponse(null, { status: 404 });
     },

--- a/test/msw-setup.ts
+++ b/test/msw-setup.ts
@@ -1,6 +1,19 @@
 import { setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
 
+// Mock data for bulk actions
+const mockBulkAction = {
+  sys: {
+    id: "test-bulk-action-id",
+    status: "succeeded",
+    version: 1
+  },
+  succeeded: [
+    { sys: { id: "test-entry-id", type: "Entry" } },
+    { sys: { id: "test-asset-id", type: "Asset" } }
+  ]
+};
+
 // Define handlers
 export const handlers = [
   // List spaces
@@ -72,6 +85,78 @@ export const handlers = [
       }
       return new HttpResponse(null, { status: 404 });
     },
+  ),
+];
+
+// Bulk action handlers
+const bulkActionHandlers = [
+  // Create bulk publish action
+  http.post(
+    "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/bulk_actions/publish",
+    async ({ params }) => {
+      const { spaceId, environmentId } = params;
+      if (spaceId === "test-space-id") {
+        return HttpResponse.json({
+          ...mockBulkAction,
+          sys: {
+            ...mockBulkAction.sys,
+            id: "test-bulk-action-id",
+            status: "created"
+          }
+        }, { status: 201 });
+      }
+      return new HttpResponse(null, { status: 404 });
+    }
+  ),
+
+  // Create bulk unpublish action
+  http.post(
+    "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/bulk_actions/unpublish",
+    async ({ params }) => {
+      const { spaceId, environmentId } = params;
+      if (spaceId === "test-space-id") {
+        return HttpResponse.json({
+          ...mockBulkAction,
+          sys: {
+            ...mockBulkAction.sys,
+            id: "test-bulk-action-id",
+            status: "created"
+          }
+        }, { status: 201 });
+      }
+      return new HttpResponse(null, { status: 404 });
+    }
+  ),
+
+  // Create bulk validate action
+  http.post(
+    "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/bulk_actions/validate",
+    async ({ params }) => {
+      const { spaceId, environmentId } = params;
+      if (spaceId === "test-space-id") {
+        return HttpResponse.json({
+          ...mockBulkAction,
+          sys: {
+            ...mockBulkAction.sys,
+            id: "test-bulk-action-id",
+            status: "created"
+          }
+        }, { status: 201 });
+      }
+      return new HttpResponse(null, { status: 404 });
+    }
+  ),
+
+  // Get bulk action status
+  http.get(
+    "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/bulk_actions/:bulkActionId",
+    ({ params }) => {
+      const { spaceId, bulkActionId } = params;
+      if (spaceId === "test-space-id" && bulkActionId === "test-bulk-action-id") {
+        return HttpResponse.json(mockBulkAction);
+      }
+      return new HttpResponse(null, { status: 404 });
+    }
   ),
 ];
 
@@ -545,4 +630,5 @@ export const server = setupServer(
   ...assetHandlers,
   ...contentTypeHandlers,
   ...entryHandlers,
+  ...bulkActionHandlers,
 );

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
-import { getSpaceEnvProperties } from "../../src/types/tools"
+import { getSpaceEnvProperties, getBulkActionTools } from "../../src/types/tools"
 
 describe("getSpaceEnvProperties", () => {
   const originalEnv = process.env
@@ -72,5 +72,65 @@ describe("getSpaceEnvProperties", () => {
     expect(result.required).toContain("existingProperty")
     expect(result.required).toContain("spaceId")
     expect(result.required).toContain("environmentId")
+  })
+})
+
+describe("getBulkActionTools", () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it("should return bulk action tools with correct structure", () => {
+    const bulkActionTools = getBulkActionTools()
+    
+    // Check if all expected bulk actions are present
+    expect(bulkActionTools).toHaveProperty("BULK_PUBLISH")
+    expect(bulkActionTools).toHaveProperty("BULK_UNPUBLISH")
+    expect(bulkActionTools).toHaveProperty("BULK_VALIDATE")
+    
+    // Check BULK_PUBLISH structure
+    expect(bulkActionTools.BULK_PUBLISH.name).toBe("bulk_publish")
+    expect(bulkActionTools.BULK_PUBLISH.description).toBe("Publish multiple entries or assets at once")
+    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).toHaveProperty("entities")
+    
+    // Check BULK_UNPUBLISH structure
+    expect(bulkActionTools.BULK_UNPUBLISH.name).toBe("bulk_unpublish")
+    expect(bulkActionTools.BULK_UNPUBLISH.description).toBe("Unpublish multiple entries or assets at once")
+    expect(bulkActionTools.BULK_UNPUBLISH.inputSchema.properties).toHaveProperty("entities")
+    
+    // Check BULK_VALIDATE structure
+    expect(bulkActionTools.BULK_VALIDATE.name).toBe("bulk_validate")
+    expect(bulkActionTools.BULK_VALIDATE.description).toBe("Validate multiple entries at once")
+    expect(bulkActionTools.BULK_VALIDATE.inputSchema.properties).toHaveProperty("entryIds")
+  })
+
+  it("should include spaceId and environmentId in schema when environment variables are not set", () => {
+    delete process.env.SPACE_ID
+    delete process.env.ENVIRONMENT_ID
+    
+    const bulkActionTools = getBulkActionTools()
+    
+    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).toHaveProperty("spaceId")
+    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).toHaveProperty("environmentId")
+    expect(bulkActionTools.BULK_PUBLISH.inputSchema.required).toContain("spaceId")
+    expect(bulkActionTools.BULK_PUBLISH.inputSchema.required).toContain("environmentId")
+  })
+
+  it("should not include spaceId and environmentId in schema when environment variables are set", () => {
+    process.env.SPACE_ID = "test-space-id"
+    process.env.ENVIRONMENT_ID = "test-environment-id"
+    
+    const bulkActionTools = getBulkActionTools()
+    
+    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).not.toHaveProperty("spaceId")
+    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).not.toHaveProperty("environmentId")
+    expect(bulkActionTools.BULK_PUBLISH.inputSchema.required || []).not.toContain("spaceId")
+    expect(bulkActionTools.BULK_PUBLISH.inputSchema.required || []).not.toContain("environmentId")
   })
 })


### PR DESCRIPTION
This pull request introduces a new feature for bulk operations in the MCP server implementation, along with corresponding updates to the documentation, codebase, and tests. The key changes are detailed below:

### Documentation Updates:
* Added a new section for Bulk Operations in `README.md`, explaining the functionality and benefits of bulk publishing, unpublishing, and validation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R35-R45) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R63) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R101)

### Codebase Enhancements:
* Added `bulkActionHandlers` to handle bulk publishing, unpublishing, and validation in `src/handlers/bulk-action-handlers.ts`.
* Updated `src/index.ts` to include `bulkActionHandlers` and register the new bulk operations. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R17) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R88-R92)
* Defined new tools for bulk actions in `src/types/tools.ts`. [[1]](diffhunk://#diff-950fb07c3d305fe53dd7d19370a42bbdc70f3e3bcc1845c6b2b1501696b9a22dL1-R9) [[2]](diffhunk://#diff-950fb07c3d305fe53dd7d19370a42bbdc70f3e3bcc1845c6b2b1501696b9a22dR500-R600)

### Testing Improvements:
* Created integration tests for bulk action handlers in `test/integration/bulk-action-handler.test.ts`.
* Updated the mock server setup to handle bulk actions in `test/msw-setup.ts`. [[1]](diffhunk://#diff-e6d3859b6e0a7a542fed2a55acda2dbe8b9d557b7d1de5591809177300f9437bR4-R16) [[2]](diffhunk://#diff-e6d3859b6e0a7a542fed2a55acda2dbe8b9d557b7d1de5591809177300f9437bL55-R86)