### PR TITLE
feat(entry-handlers): add support for bulk publishing and unpublishin…

### DIFF
--- a/src/handlers/entry-handlers.ts
+++ b/src/handlers/entry-handlers.ts
@@ -142,64 +142,42 @@ export const entryHandlers = {
     
     // If entryId is an array, handle bulk publishing
     if (Array.isArray(entryId)) {
-      // Get the bulkActionHandlers if they exist
       try {
-        const { bulkActionHandlers } = await import("./bulk-action-handlers.js")
-        
-        // Map entry IDs to the expected format for bulkPublish
-        const entities = entryId.map(id => ({
-          sys: { id, type: "Entry" as const }
-        }))
-        
-        return bulkActionHandlers.bulkPublish({
-          spaceId,
-          environmentId,
-          entities
-        })
-      } catch (error) {
-        // Fall back to our own implementation if the import fails
-        console.warn("Failed to import bulk-action-handlers.js, using fallback implementation:", error)
-        
-        // Map entry IDs to the expected format for bulk publishing
-        const entities = entryId.map(id => ({
-          sys: { id, type: "Entry" as const }
-        }))
-        
         const contentfulClient = await getContentfulClient()
         
         // Get the current version of each entity
-        const entityVersions = await Promise.all(
-          entities.map(async (entity) => {
+        const entryVersions = await Promise.all(
+          entryId.map(async (id) => {
             try {
               // Get the current version of the entry
               const currentEntry = await contentfulClient.entry.get({
                 spaceId,
                 environmentId,
-                entryId: entity.sys.id
+                entryId: id
               })
               
-              // Create a versioned link
+              // Create a versioned link according to the API docs
               return {
                 sys: {
                   type: "Link",
                   linkType: "Entry",
-                  id: entity.sys.id,
+                  id: id,
                   version: currentEntry.sys.version
                 }
               }
             } catch (error) {
-              console.error(`Error fetching entry ${entity.sys.id}: ${error}`)
-              throw new Error(`Failed to get version for entry ${entity.sys.id}. All entries must have a version.`)
+              console.error(`Error fetching entry ${id}: ${error}`)
+              throw new Error(`Failed to get version for entry ${id}. All entries must have a version.`)
             }
           })
         )
         
-        // Create the collection object
-        const entitiesCollection = {
-          sys: {
-            type: "Array"
+        // Create the correct entities format according to Contentful API docs
+        const entities = {
+          sys: { 
+            type: "Array" 
           },
-          items: entityVersions
+          items: entryVersions
         }
         
         // Create the bulk action
@@ -209,7 +187,7 @@ export const entryHandlers = {
             environmentId,
           },
           {
-            entities: entitiesCollection,
+            entities
           }
         )
         
@@ -240,6 +218,16 @@ export const entryHandlers = {
               }`,
             },
           ],
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error during bulk publish: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ],
+          isError: true
         }
       }
     }
@@ -285,64 +273,42 @@ export const entryHandlers = {
     
     // If entryId is an array, handle bulk unpublishing
     if (Array.isArray(entryId)) {
-      // Get the bulkActionHandlers if they exist
       try {
-        const { bulkActionHandlers } = await import("./bulk-action-handlers.js")
-        
-        // Map entry IDs to the expected format for bulkUnpublish
-        const entities = entryId.map(id => ({
-          sys: { id, type: "Entry" as const }
-        }))
-        
-        return bulkActionHandlers.bulkUnpublish({
-          spaceId,
-          environmentId,
-          entities
-        })
-      } catch (error) {
-        // Fall back to our own implementation if the import fails
-        console.warn("Failed to import bulk-action-handlers.js, using fallback implementation:", error)
-        
-        // Map entry IDs to the expected format for bulk unpublishing
-        const entities = entryId.map(id => ({
-          sys: { id, type: "Entry" as const }
-        }))
-        
         const contentfulClient = await getContentfulClient()
         
         // Get the current version of each entity
-        const entityVersions = await Promise.all(
-          entities.map(async (entity) => {
+        const entryVersions = await Promise.all(
+          entryId.map(async (id) => {
             try {
               // Get the current version of the entry
               const currentEntry = await contentfulClient.entry.get({
                 spaceId,
                 environmentId,
-                entryId: entity.sys.id
+                entryId: id
               })
               
-              // Create a versioned link
+              // Create a versioned link according to the API docs
               return {
                 sys: {
                   type: "Link",
                   linkType: "Entry",
-                  id: entity.sys.id,
+                  id: id,
                   version: currentEntry.sys.version
                 }
               }
             } catch (error) {
-              console.error(`Error fetching entry ${entity.sys.id}: ${error}`)
-              throw new Error(`Failed to get version for entry ${entity.sys.id}. All entries must have a version.`)
+              console.error(`Error fetching entry ${id}: ${error}`)
+              throw new Error(`Failed to get version for entry ${id}. All entries must have a version.`)
             }
           })
         )
         
-        // Create the collection object
-        const entitiesCollection = {
-          sys: {
-            type: "Array"
+        // Create the correct entities format according to Contentful API docs
+        const entities = {
+          sys: { 
+            type: "Array" 
           },
-          items: entityVersions
+          items: entryVersions
         }
         
         // Create the bulk action
@@ -352,7 +318,7 @@ export const entryHandlers = {
             environmentId,
           },
           {
-            entities: entitiesCollection,
+            entities
           }
         )
         
@@ -383,6 +349,16 @@ export const entryHandlers = {
               }`,
             },
           ],
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error during bulk unpublish: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ],
+          isError: true
         }
       }
     }

--- a/src/handlers/entry-handlers.ts
+++ b/src/handlers/entry-handlers.ts
@@ -121,14 +121,115 @@ export const entryHandlers = {
     }
   },
 
-  publishEntry: async (args: { spaceId: string; environmentId: string; entryId: string }) => {
+  publishEntry: async (args: { 
+    spaceId: string; 
+    environmentId: string; 
+    entryId: string | string[] 
+  }) => {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
-
+    
+    // Handle case where entryId is a JSON string representation of an array
+    let entryId = args.entryId
+    if (typeof entryId === 'string' && entryId.startsWith('[') && entryId.endsWith(']')) {
+      try {
+        entryId = JSON.parse(entryId)
+      } catch (e) {
+        // If parsing fails, keep it as string
+        console.error('Failed to parse entryId as JSON array:', e)
+      }
+    }
+    
+    // If entryId is an array, handle bulk publishing
+    if (Array.isArray(entryId)) {
+      // Map entry IDs to the expected format for bulk publishing
+      const entities = entryId.map(id => ({
+        sys: { id, type: "Entry" as const }
+      }))
+      
+      const contentfulClient = await getContentfulClient()
+      
+      // Get the current version of each entity
+      const entityVersions = await Promise.all(
+        entities.map(async (entity) => {
+          try {
+            // Get the current version of the entry
+            const currentEntry = await contentfulClient.entry.get({
+              spaceId,
+              environmentId,
+              entryId: entity.sys.id
+            })
+            
+            // Create a versioned link
+            return {
+              sys: {
+                type: "Link",
+                linkType: "Entry",
+                id: entity.sys.id,
+                version: currentEntry.sys.version
+              }
+            }
+          } catch (error) {
+            console.error(`Error fetching entry ${entity.sys.id}: ${error}`)
+            throw new Error(`Failed to get version for entry ${entity.sys.id}. All entries must have a version.`)
+          }
+        })
+      )
+      
+      // Create the collection object
+      const entitiesCollection = {
+        sys: {
+          type: "Array"
+        },
+        items: entityVersions
+      }
+      
+      // Create the bulk action
+      const bulkAction = await contentfulClient.bulkAction.publish(
+        {
+          spaceId,
+          environmentId,
+        },
+        {
+          entities: entitiesCollection,
+        }
+      )
+      
+      // Wait for the bulk action to complete
+      let action = await contentfulClient.bulkAction.get({
+        spaceId,
+        environmentId,
+        bulkActionId: bulkAction.sys.id,
+      })
+      
+      while (action.sys.status === "inProgress" || action.sys.status === "created") {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        action = await contentfulClient.bulkAction.get({
+          spaceId,
+          environmentId,
+          bulkActionId: bulkAction.sys.id,
+        })
+      }
+      
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Bulk publish completed with status: ${action.sys.status}. ${
+              action.sys.status === "failed"
+                ? `Error: ${JSON.stringify(action.error)}`
+                : `Successfully processed ${action.succeeded?.length || 0} items.`
+            }`,
+          },
+        ],
+      }
+    }
+    
+    // Handle single entry publishing
     const params = {
       spaceId,
       environmentId,
-      entryId: args.entryId,
+      entryId: entryId as string,
     }
 
     const contentfulClient = await getContentfulClient()
@@ -138,19 +239,121 @@ export const entryHandlers = {
       sys: currentEntry.sys,
       fields: currentEntry.fields,
     })
+    
     return {
       content: [{ type: "text", text: JSON.stringify(entry, null, 2) }],
     }
   },
 
-  unpublishEntry: async (args: { spaceId: string; environmentId: string; entryId: string }) => {
+  unpublishEntry: async (args: { 
+    spaceId: string; 
+    environmentId: string; 
+    entryId: string | string[] 
+  }) => {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
 
+    // Handle case where entryId is a JSON string representation of an array
+    let entryId = args.entryId
+    if (typeof entryId === 'string' && entryId.startsWith('[') && entryId.endsWith(']')) {
+      try {
+        entryId = JSON.parse(entryId)
+      } catch (e) {
+        // If parsing fails, keep it as string
+        console.error('Failed to parse entryId as JSON array:', e)
+      }
+    }
+    
+    // If entryId is an array, handle bulk unpublishing
+    if (Array.isArray(entryId)) {
+      // Map entry IDs to the expected format for bulk unpublishing
+      const entities = entryId.map(id => ({
+        sys: { id, type: "Entry" as const }
+      }))
+      
+      const contentfulClient = await getContentfulClient()
+      
+      // Get the current version of each entity
+      const entityVersions = await Promise.all(
+        entities.map(async (entity) => {
+          try {
+            // Get the current version of the entry
+            const currentEntry = await contentfulClient.entry.get({
+              spaceId,
+              environmentId,
+              entryId: entity.sys.id
+            })
+            
+            // Create a versioned link
+            return {
+              sys: {
+                type: "Link",
+                linkType: "Entry",
+                id: entity.sys.id,
+                version: currentEntry.sys.version
+              }
+            }
+          } catch (error) {
+            console.error(`Error fetching entry ${entity.sys.id}: ${error}`)
+            throw new Error(`Failed to get version for entry ${entity.sys.id}. All entries must have a version.`)
+          }
+        })
+      )
+      
+      // Create the collection object
+      const entitiesCollection = {
+        sys: {
+          type: "Array"
+        },
+        items: entityVersions
+      }
+      
+      // Create the bulk action
+      const bulkAction = await contentfulClient.bulkAction.unpublish(
+        {
+          spaceId,
+          environmentId,
+        },
+        {
+          entities: entitiesCollection,
+        }
+      )
+      
+      // Wait for the bulk action to complete
+      let action = await contentfulClient.bulkAction.get({
+        spaceId,
+        environmentId,
+        bulkActionId: bulkAction.sys.id,
+      })
+      
+      while (action.sys.status === "inProgress" || action.sys.status === "created") {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        action = await contentfulClient.bulkAction.get({
+          spaceId,
+          environmentId,
+          bulkActionId: bulkAction.sys.id,
+        })
+      }
+      
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Bulk unpublish completed with status: ${action.sys.status}. ${
+              action.sys.status === "failed"
+                ? `Error: ${JSON.stringify(action.error)}`
+                : `Successfully processed ${action.succeeded?.length || 0} items.`
+            }`,
+          },
+        ],
+      }
+    }
+    
+    // Handle single entry unpublishing
     const params = {
       spaceId,
       environmentId,
-      entryId: args.entryId,
+      entryId: entryId as string,
     }
 
     const contentfulClient = await getContentfulClient()

--- a/src/handlers/entry-handlers.ts
+++ b/src/handlers/entry-handlers.ts
@@ -1,7 +1,34 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getContentfulClient } from "../config/client.js"
 import { summarizeData } from "../utils/summarizer.js"
-import { CreateEntryProps, EntryProps, QueryOptions } from "contentful-management"
+import { 
+  CreateEntryProps, 
+  EntryProps, 
+  QueryOptions, 
+  BulkActionProps, 
+  Link,
+  Collection 
+} from "contentful-management"
+
+// Define the interface for bulk action responses with succeeded property
+interface BulkActionResponse extends BulkActionProps<any> {
+  succeeded?: Array<{
+    sys: {
+      id: string;
+      type: string;
+    }
+  }>;
+}
+
+// Define the interface for versioned links
+interface VersionedLink {
+  sys: {
+    type: "Link";
+    linkType: "Entry" | "Asset";
+    id: string;
+    version: number;
+  }
+}
 
 export const entryHandlers = {
   searchEntries: async (args: { spaceId: string; environmentId: string; query: QueryOptions }) => {
@@ -157,7 +184,7 @@ export const entryHandlers = {
               })
               
               // Create a versioned link according to the API docs
-              return {
+              const versionedLink: VersionedLink = {
                 sys: {
                   type: "Link",
                   linkType: "Entry",
@@ -165,6 +192,7 @@ export const entryHandlers = {
                   version: currentEntry.sys.version
                 }
               }
+              return versionedLink
             } catch (error) {
               console.error(`Error fetching entry ${id}: ${error}`)
               throw new Error(`Failed to get version for entry ${id}. All entries must have a version.`)
@@ -173,7 +201,10 @@ export const entryHandlers = {
         )
         
         // Create the correct entities format according to Contentful API docs
-        const entities = {
+        const entities: { 
+          sys: { type: "Array" }, 
+          items: VersionedLink[] 
+        } = {
           sys: { 
             type: "Array" 
           },
@@ -196,7 +227,7 @@ export const entryHandlers = {
           spaceId,
           environmentId,
           bulkActionId: bulkAction.sys.id,
-        })
+        }) as BulkActionResponse // Cast to our extended interface
         
         while (action.sys.status === "inProgress" || action.sys.status === "created") {
           await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -204,7 +235,7 @@ export const entryHandlers = {
             spaceId,
             environmentId,
             bulkActionId: bulkAction.sys.id,
-          })
+          }) as BulkActionResponse // Cast to our extended interface
         }
         
         return {
@@ -288,7 +319,7 @@ export const entryHandlers = {
               })
               
               // Create a versioned link according to the API docs
-              return {
+              const versionedLink: VersionedLink = {
                 sys: {
                   type: "Link",
                   linkType: "Entry",
@@ -296,6 +327,7 @@ export const entryHandlers = {
                   version: currentEntry.sys.version
                 }
               }
+              return versionedLink
             } catch (error) {
               console.error(`Error fetching entry ${id}: ${error}`)
               throw new Error(`Failed to get version for entry ${id}. All entries must have a version.`)
@@ -304,7 +336,10 @@ export const entryHandlers = {
         )
         
         // Create the correct entities format according to Contentful API docs
-        const entities = {
+        const entities: { 
+          sys: { type: "Array" }, 
+          items: VersionedLink[] 
+        } = {
           sys: { 
             type: "Array" 
           },
@@ -327,7 +362,7 @@ export const entryHandlers = {
           spaceId,
           environmentId,
           bulkActionId: bulkAction.sys.id,
-        })
+        }) as BulkActionResponse // Cast to our extended interface
         
         while (action.sys.status === "inProgress" || action.sys.status === "created") {
           await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -335,7 +370,7 @@ export const entryHandlers = {
             spaceId,
             environmentId,
             bulkActionId: bulkAction.sys.id,
-          })
+          }) as BulkActionResponse // Cast to our extended interface
         }
         
         return {

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -116,22 +116,46 @@ export const getEntryTools = () => {
     },
     PUBLISH_ENTRY: {
       name: "publish_entry",
-      description: "Publish an entry",
+      description:
+        "Publish an entry or multiple entries. Accepts either a single entryId (string) or an array of entryIds (up to 100 entries). For a single entry, it uses the standard publish operation. For multiple entries, it automatically uses bulk publishing.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
-          entryId: { type: "string" },
+          entryId: { 
+            oneOf: [
+              { type: "string" },
+              { 
+                type: "array", 
+                items: { type: "string" },
+                maxItems: 100,
+                description: "Array of entry IDs to publish (max: 100)"
+              }
+            ],
+            description: "ID of the entry to publish, or an array of entry IDs (max: 100)"
+          },
         },
         required: ["entryId"],
       }),
     },
     UNPUBLISH_ENTRY: {
       name: "unpublish_entry",
-      description: "Unpublish an entry",
+      description:
+        "Unpublish an entry or multiple entries. Accepts either a single entryId (string) or an array of entryIds (up to 100 entries). For a single entry, it uses the standard unpublish operation. For multiple entries, it automatically uses bulk unpublishing.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
-          entryId: { type: "string" },
+          entryId: { 
+            oneOf: [
+              { type: "string" },
+              { 
+                type: "array", 
+                items: { type: "string" },
+                maxItems: 100,
+                description: "Array of entry IDs to unpublish (max: 100)"
+              }
+            ],
+            description: "ID of the entry to unpublish, or an array of entry IDs (max: 100)"
+          },
         },
         required: ["entryId"],
       }),

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -129,17 +129,17 @@ export const getEntryTools = () => {
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
-          entryId: { 
+          entryId: {
             oneOf: [
               { type: "string" },
-              { 
-                type: "array", 
+              {
+                type: "array",
                 items: { type: "string" },
                 maxItems: 100,
-                description: "Array of entry IDs to publish (max: 100)"
-              }
+                description: "Array of entry IDs to publish (max: 100)",
+              },
             ],
-            description: "ID of the entry to publish, or an array of entry IDs (max: 100)"
+            description: "ID of the entry to publish, or an array of entry IDs (max: 100)",
           },
         },
         required: ["entryId"],
@@ -152,17 +152,17 @@ export const getEntryTools = () => {
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
-          entryId: { 
+          entryId: {
             oneOf: [
               { type: "string" },
-              { 
-                type: "array", 
+              {
+                type: "array",
                 items: { type: "string" },
                 maxItems: 100,
-                description: "Array of entry IDs to unpublish (max: 100)"
-              }
+                description: "Array of entry IDs to unpublish (max: 100)",
+              },
             ],
-            description: "ID of the entry to unpublish, or an array of entry IDs (max: 100)"
+            description: "ID of the entry to unpublish, or an array of entry IDs (max: 100)",
           },
         },
         required: ["entryId"],
@@ -524,76 +524,6 @@ export const getSpaceEnvTools = () => {
 // Tool definitions for Bulk Actions
 export const getBulkActionTools = () => {
   return {
-    BULK_PUBLISH: {
-      name: "bulk_publish",
-      description: "Publish multiple entries or assets at once",
-      inputSchema: getSpaceEnvProperties({
-        type: "object",
-        properties: {
-          entities: {
-            type: "array",
-            description: "Array of entries or assets to publish",
-            items: {
-              type: "object",
-              properties: {
-                sys: {
-                  type: "object",
-                  properties: {
-                    id: {
-                      type: "string",
-                      description: "ID of the entry or asset",
-                    },
-                    type: {
-                      type: "string",
-                      enum: ["Entry", "Asset"],
-                      description: "Type of entity (Entry or Asset)",
-                    },
-                  },
-                  required: ["id", "type"],
-                },
-              },
-              required: ["sys"],
-            },
-          },
-        },
-        required: ["entities"],
-      }),
-    },
-    BULK_UNPUBLISH: {
-      name: "bulk_unpublish",
-      description: "Unpublish multiple entries or assets at once",
-      inputSchema: getSpaceEnvProperties({
-        type: "object",
-        properties: {
-          entities: {
-            type: "array",
-            description: "Array of entries or assets to unpublish",
-            items: {
-              type: "object",
-              properties: {
-                sys: {
-                  type: "object",
-                  properties: {
-                    id: {
-                      type: "string",
-                      description: "ID of the entry or asset",
-                    },
-                    type: {
-                      type: "string",
-                      enum: ["Entry", "Asset"],
-                      description: "Type of entity (Entry or Asset)",
-                    },
-                  },
-                  required: ["id", "type"],
-                },
-              },
-              required: ["sys"],
-            },
-          },
-        },
-        required: ["entities"],
-      }),
-    },
     BULK_VALIDATE: {
       name: "bulk_validate",
       description: "Validate multiple entries at once",

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
-import { getSpaceEnvProperties, getBulkActionTools } from "../../src/types/tools"
+import { getSpaceEnvProperties } from "../../src/types/tools"
 
 describe("getSpaceEnvProperties", () => {
   const originalEnv = process.env
@@ -72,65 +72,5 @@ describe("getSpaceEnvProperties", () => {
     expect(result.required).toContain("existingProperty")
     expect(result.required).toContain("spaceId")
     expect(result.required).toContain("environmentId")
-  })
-})
-
-describe("getBulkActionTools", () => {
-  const originalEnv = process.env
-
-  beforeEach(() => {
-    process.env = { ...originalEnv }
-  })
-
-  afterEach(() => {
-    process.env = originalEnv
-  })
-
-  it("should return bulk action tools with correct structure", () => {
-    const bulkActionTools = getBulkActionTools()
-    
-    // Check if all expected bulk actions are present
-    expect(bulkActionTools).toHaveProperty("BULK_PUBLISH")
-    expect(bulkActionTools).toHaveProperty("BULK_UNPUBLISH")
-    expect(bulkActionTools).toHaveProperty("BULK_VALIDATE")
-    
-    // Check BULK_PUBLISH structure
-    expect(bulkActionTools.BULK_PUBLISH.name).toBe("bulk_publish")
-    expect(bulkActionTools.BULK_PUBLISH.description).toBe("Publish multiple entries or assets at once")
-    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).toHaveProperty("entities")
-    
-    // Check BULK_UNPUBLISH structure
-    expect(bulkActionTools.BULK_UNPUBLISH.name).toBe("bulk_unpublish")
-    expect(bulkActionTools.BULK_UNPUBLISH.description).toBe("Unpublish multiple entries or assets at once")
-    expect(bulkActionTools.BULK_UNPUBLISH.inputSchema.properties).toHaveProperty("entities")
-    
-    // Check BULK_VALIDATE structure
-    expect(bulkActionTools.BULK_VALIDATE.name).toBe("bulk_validate")
-    expect(bulkActionTools.BULK_VALIDATE.description).toBe("Validate multiple entries at once")
-    expect(bulkActionTools.BULK_VALIDATE.inputSchema.properties).toHaveProperty("entryIds")
-  })
-
-  it("should include spaceId and environmentId in schema when environment variables are not set", () => {
-    delete process.env.SPACE_ID
-    delete process.env.ENVIRONMENT_ID
-    
-    const bulkActionTools = getBulkActionTools()
-    
-    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).toHaveProperty("spaceId")
-    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).toHaveProperty("environmentId")
-    expect(bulkActionTools.BULK_PUBLISH.inputSchema.required).toContain("spaceId")
-    expect(bulkActionTools.BULK_PUBLISH.inputSchema.required).toContain("environmentId")
-  })
-
-  it("should not include spaceId and environmentId in schema when environment variables are set", () => {
-    process.env.SPACE_ID = "test-space-id"
-    process.env.ENVIRONMENT_ID = "test-environment-id"
-    
-    const bulkActionTools = getBulkActionTools()
-    
-    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).not.toHaveProperty("spaceId")
-    expect(bulkActionTools.BULK_PUBLISH.inputSchema.properties).not.toHaveProperty("environmentId")
-    expect(bulkActionTools.BULK_PUBLISH.inputSchema.required || []).not.toContain("spaceId")
-    expect(bulkActionTools.BULK_PUBLISH.inputSchema.required || []).not.toContain("environmentId")
   })
 })


### PR DESCRIPTION
This pull request introduces support for bulk publishing and unpublishing of entries in the Contentful integration. The changes include updates to the `publishEntry` and `unpublishEntry` handlers to handle arrays of entry IDs, modifications to the input schema, and new tests to ensure the functionality works as expected.

Enhancements to entry handlers:

* [`src/handlers/entry-handlers.ts`](diffhunk://#diff-a970835e531d11d284d2af8f7014cb3d30bad3c2df7d009c11931a0f6ba9da98L124-R232): Updated `publishEntry` and `unpublishEntry` handlers to accept an array of entry IDs and handle bulk operations. Added logic to parse and process JSON string representations of arrays. [[1]](diffhunk://#diff-a970835e531d11d284d2af8f7014cb3d30bad3c2df7d009c11931a0f6ba9da98L124-R232) [[2]](diffhunk://#diff-a970835e531d11d284d2af8f7014cb3d30bad3c2df7d009c11931a0f6ba9da98R242-R356)

Schema updates:

* [`src/types/tools.ts`](diffhunk://#diff-950fb07c3d305fe53dd7d19370a42bbdc70f3e3bcc1845c6b2b1501696b9a22dL119-R158): Modified the `PUBLISH_ENTRY` and `UNPUBLISH_ENTRY` descriptions and input schemas to support single entry IDs or arrays of entry IDs (up to 100 entries).

Testing improvements:

* [`test/integration/entry-handler.test.ts`](diffhunk://#diff-db58babb85b15fdf53ea7306c4db138f2046ddc2baf9c94e0070acdc0a730151L1-R65): Added mocks for the Contentful client to simulate bulk operations and created new integration tests for bulk publishing and unpublishing. [[1]](diffhunk://#diff-db58babb85b15fdf53ea7306c4db138f2046ddc2baf9c94e0070acdc0a730151L1-R65) [[2]](diffhunk://#diff-db58babb85b15fdf53ea7306c4db138f2046ddc2baf9c94e0070acdc0a730151R196-R205) [[3]](diffhunk://#diff-db58babb85b15fdf53ea7306c4db138f2046ddc2baf9c94e0070acdc0a730151R219-R228)…g entries

refactor(entry-handlers): enhance entry publish and unpublish methods to handle single and multiple entries

test(entry-handlers): add integration tests for bulk entry publishing and unpublishing