### PR TITLE
create_content_type handler updated to create Content Type ID based on Name Property

### DIFF
--- a/src/handlers/content-type-handlers.ts
+++ b/src/handlers/content-type-handlers.ts
@@ -50,7 +50,18 @@ export const contentTypeHandlers = {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
 
+    const toCamelCase = (str: string): string =>
+      str
+        .split(/\s+/)
+        .map((word: string, index: number) =>
+          index === 0
+            ? word.toLowerCase()
+            : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+        )
+        .join("")
+
     const params = {
+      contentTypeId: toCamelCase(args.name),
       spaceId,
       environmentId,
     }
@@ -63,7 +74,8 @@ export const contentTypeHandlers = {
     }
 
     const contentfulClient = await getContentfulClient()
-    const contentType = await contentfulClient.contentType.create(params, contentTypeProps)
+    const contentType = await contentfulClient.contentType.createWithId(params, contentTypeProps)
+
     return {
       content: [{ type: "text", text: JSON.stringify(contentType, null, 2) }],
     }


### PR DESCRIPTION
I kept it compact for now "toCamelCase" helper is in the handler...I didn't see the need anywhere else off hand. Tested and works. Content Type with a name of "Hairless Dog" will create a c.type with "hairlessDog" as the id.