### PR TITLE
Create ctype name based

### DIFF
--- a/src/handlers/content-type-handlers.ts
+++ b/src/handlers/content-type-handlers.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getContentfulClient } from "../config/client.js"
 import { ContentTypeProps, CreateContentTypeProps } from "contentful-management"
+import { toCamelCase } from "../utils/to-camel-case.js"
 
 export const contentTypeHandlers = {
   listContentTypes: async (args: { spaceId: string; environmentId: string }) => {
@@ -49,16 +50,6 @@ export const contentTypeHandlers = {
   }) => {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
-
-    const toCamelCase = (str: string): string =>
-      str
-        .split(/\s+/)
-        .map((word: string, index: number) =>
-          index === 0
-            ? word.toLowerCase()
-            : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
-        )
-        .join("")
 
     const params = {
       contentTypeId: toCamelCase(args.name),

--- a/src/handlers/content-type-handlers.ts
+++ b/src/handlers/content-type-handlers.ts
@@ -50,7 +50,18 @@ export const contentTypeHandlers = {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
 
+    const toCamelCase = (str: string): string =>
+      str
+        .split(/\s+/)
+        .map((word: string, index: number) =>
+          index === 0
+            ? word.toLowerCase()
+            : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+        )
+        .join("")
+
     const params = {
+      contentTypeId: toCamelCase(args.name),
       spaceId,
       environmentId,
     }
@@ -63,7 +74,8 @@ export const contentTypeHandlers = {
     }
 
     const contentfulClient = await getContentfulClient()
-    const contentType = await contentfulClient.contentType.create(params, contentTypeProps)
+    const contentType = await contentfulClient.contentType.createWithId(params, contentTypeProps)
+
     return {
       content: [{ type: "text", text: JSON.stringify(contentType, null, 2) }],
     }

--- a/src/utils/to-camel-case.ts
+++ b/src/utils/to-camel-case.ts
@@ -1,0 +1,7 @@
+export const toCamelCase = (str: string): string =>
+  str
+    .split(/\s+/)
+    .map((word: string, index: number) =>
+      index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+    )
+    .join("")

--- a/test/integration/content-type-handler.test.ts
+++ b/test/integration/content-type-handler.test.ts
@@ -1,64 +1,59 @@
-import { expect } from "vitest";
-import { contentTypeHandlers } from "../../src/handlers/content-type-handlers.js";
-import { server } from "../msw-setup.js";
+import { expect } from "vitest"
+import { contentTypeHandlers } from "../../src/handlers/content-type-handlers.js"
+import { server } from "../msw-setup.js"
+import { toCamelCase } from "../../src/utils/to-camel-case.js"
 
 describe("Content Type Handlers Integration Tests", () => {
   // Start MSW Server before tests
-  beforeAll(() => server.listen());
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
 
-  const testSpaceId = "test-space-id";
-  const testContentTypeId = "test-content-type-id";
+  const testSpaceId = "test-space-id"
+  const testContentTypeId = "test-content-type-id"
 
   describe("listContentTypes", () => {
     it("should list all content types", async () => {
       const result = await contentTypeHandlers.listContentTypes({
         spaceId: testSpaceId,
-      });
+      })
 
-      expect(result).to.have.property("content").that.is.an("array");
-      expect(result.content).to.have.lengthOf(1);
+      expect(result).to.have.property("content").that.is.an("array")
+      expect(result.content).to.have.lengthOf(1)
 
-      const contentTypes = JSON.parse(result.content[0].text);
-      expect(contentTypes.items).to.be.an("array");
-      expect(contentTypes.items[0]).to.have.nested.property(
-        "sys.id",
-        "test-content-type-id",
-      );
-      expect(contentTypes.items[0]).to.have.property(
-        "name",
-        "Test Content Type",
-      );
-    });
-  });
+      const contentTypes = JSON.parse(result.content[0].text)
+      expect(contentTypes.items).to.be.an("array")
+      expect(contentTypes.items[0]).to.have.nested.property("sys.id", "test-content-type-id")
+      expect(contentTypes.items[0]).to.have.property("name", "Test Content Type")
+    })
+  })
 
   describe("getContentType", () => {
     it("should get details of a specific content type", async () => {
       const result = await contentTypeHandlers.getContentType({
         spaceId: testSpaceId,
         contentTypeId: testContentTypeId,
-      });
+      })
 
-      expect(result).to.have.property("content");
-      const contentType = JSON.parse(result.content[0].text);
-      expect(contentType).to.have.nested.property("sys.id", testContentTypeId);
-      expect(contentType).to.have.property("name", "Test Content Type");
-      expect(contentType.fields).to.be.an("array");
-    });
+      expect(result).to.have.property("content")
+      const contentType = JSON.parse(result.content[0].text)
+      expect(contentType).to.have.nested.property("sys.id", toCamelCase(testContentTypeId))
+      expect(contentType).to.have.property("name", "Test Content Type")
+      expect(contentType.fields).to.be.an("array")
+    })
 
     it("should throw error for invalid content type ID", async () => {
       try {
         await contentTypeHandlers.getContentType({
           spaceId: testSpaceId,
           contentTypeId: "invalid-id",
-        });
-        expect.fail("Should have thrown an error");
+        })
+        expect.fail("Should have thrown an error")
       } catch (error) {
-        expect(error).to.exist;
+        expect(error).to.exist
       }
-    });
-  });
+    })
+  })
 
   describe("createContentType", () => {
     it("should create a new content type", async () => {
@@ -73,21 +68,17 @@ describe("Content Type Handlers Integration Tests", () => {
             required: true,
           },
         ],
-      };
+      }
 
-      const result =
-        await contentTypeHandlers.createContentType(contentTypeData);
+      const result = await contentTypeHandlers.createContentType(contentTypeData)
 
-      expect(result).to.have.property("content");
-      const contentType = JSON.parse(result.content[0].text);
-      expect(contentType).to.have.nested.property(
-        "sys.id",
-        "new-content-type-id",
-      );
-      expect(contentType).to.have.property("name", "New Content Type");
-      expect(contentType.fields).to.be.an("array");
-    });
-  });
+      expect(result).to.have.property("content")
+      const contentType = JSON.parse(result.content[0].text)
+      expect(contentType).to.have.nested.property("sys.id", "newContentType")
+      expect(contentType).to.have.property("name", "New Content Type")
+      expect(contentType.fields).to.be.an("array")
+    })
+  })
 
   describe("updateContentType", () => {
     it("should update an existing content type", async () => {
@@ -103,62 +94,62 @@ describe("Content Type Handlers Integration Tests", () => {
             required: true,
           },
         ],
-      };
+      }
 
-      const result = await contentTypeHandlers.updateContentType(updateData);
+      const result = await contentTypeHandlers.updateContentType(updateData)
 
-      expect(result).to.have.property("content");
-      const contentType = JSON.parse(result.content[0].text);
-      expect(contentType).to.have.nested.property("sys.id", testContentTypeId);
-      expect(contentType).to.have.property("name", "Updated Content Type");
-    });
-  });
+      expect(result).to.have.property("content")
+      const contentType = JSON.parse(result.content[0].text)
+      expect(contentType).to.have.nested.property("sys.id", testContentTypeId)
+      expect(contentType).to.have.property("name", "Updated Content Type")
+    })
+  })
 
   describe("deleteContentType", () => {
     it("should delete a content type", async () => {
       const result = await contentTypeHandlers.deleteContentType({
         spaceId: testSpaceId,
         contentTypeId: testContentTypeId,
-      });
+      })
 
-      expect(result).to.have.property("content");
-      expect(result.content[0].text).to.include("deleted successfully");
-    });
+      expect(result).to.have.property("content")
+      expect(result.content[0].text).to.include("deleted successfully")
+    })
 
     it("should throw error when deleting non-existent content type", async () => {
       try {
         await contentTypeHandlers.deleteContentType({
           spaceId: testSpaceId,
           contentTypeId: "non-existent-id",
-        });
-        expect.fail("Should have thrown an error");
+        })
+        expect.fail("Should have thrown an error")
       } catch (error) {
-        expect(error).to.exist;
+        expect(error).to.exist
       }
-    });
-  });
+    })
+  })
 
   describe("publishContentType", () => {
     it("should publish a content type", async () => {
       const result = await contentTypeHandlers.publishContentType({
         spaceId: testSpaceId,
         contentTypeId: testContentTypeId,
-      });
+      })
 
-      expect(result).to.have.property("content");
-      expect(result.content[0].text).to.include("published successfully");
-    });
+      expect(result).to.have.property("content")
+      expect(result.content[0].text).to.include("published successfully")
+    })
 
     it("should throw error when publishing non-existent content type", async () => {
       try {
         await contentTypeHandlers.publishContentType({
           spaceId: testSpaceId,
           contentTypeId: "non-existent-id",
-        });
-        expect.fail("Should have thrown an error");
+        })
+        expect.fail("Should have thrown an error")
       } catch (error) {
-        expect(error).to.exist;
+        expect(error).to.exist
       }
-    });
-  });
-});
+    })
+  })
+})

--- a/test/msw-setup.ts
+++ b/test/msw-setup.ts
@@ -1,18 +1,18 @@
-import { setupServer } from "msw/node";
-import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node"
+import { http, HttpResponse } from "msw"
 
 // Mock data for bulk actions
 const mockBulkAction = {
   sys: {
     id: "test-bulk-action-id",
     status: "succeeded",
-    version: 1
+    version: 1,
   },
   succeeded: [
     { sys: { id: "test-entry-id", type: "Entry" } },
-    { sys: { id: "test-asset-id", type: "Asset" } }
-  ]
-};
+    { sys: { id: "test-asset-id", type: "Asset" } },
+  ],
+}
 
 // Define handlers
 export const handlers = [
@@ -25,82 +25,76 @@ export const handlers = [
           name: "Test Space",
         },
       ],
-    });
+    })
   }),
 
   // Get specific space
   http.get("https://api.contentful.com/spaces/:spaceId", ({ params }) => {
-    const { spaceId } = params;
+    const { spaceId } = params
     if (spaceId === "test-space-id") {
       return HttpResponse.json({
         sys: { id: "test-space-id" },
         name: "Test Space",
-      });
+      })
     }
-    return new HttpResponse(null, { status: 404 });
+    return new HttpResponse(null, { status: 404 })
   }),
 
   // List environments
-  http.get(
-    "https://api.contentful.com/spaces/:spaceId/environments",
-    ({ params }) => {
-      const { spaceId } = params;
-      if (spaceId === "test-space-id") {
-        return HttpResponse.json({
-          items: [
-            {
-              sys: { id: "master" },
-              name: "master",
-            },
-          ],
-        });
-      }
-      return new HttpResponse(null, { status: 404 });
-    },
-  ),
+  http.get("https://api.contentful.com/spaces/:spaceId/environments", ({ params }) => {
+    const { spaceId } = params
+    if (spaceId === "test-space-id") {
+      return HttpResponse.json({
+        items: [
+          {
+            sys: { id: "master" },
+            name: "master",
+          },
+        ],
+      })
+    }
+    return new HttpResponse(null, { status: 404 })
+  }),
 
   // Create environment
   http.post(
     "https://api.contentful.com/spaces/:spaceId/environments",
     async ({ params, request }) => {
-      const { spaceId } = params;
+      const { spaceId } = params
       if (spaceId === "test-space-id") {
         try {
           // Get data from request body
-          const body = await request.json();
-          console.log("Request body:", JSON.stringify(body));
-          
-          // In the real API implementation, the environmentId is taken 
+          const body = await request.json()
+          console.log("Request body:", JSON.stringify(body))
+
+          // In the real API implementation, the environmentId is taken
           // from the second argument to client.environment.create
           // We need to extract it from the name in our mock
-          const environmentId = body.name;
-          
+          const environmentId = body?.name
+
           // Return correctly structured response with environment ID
           return HttpResponse.json({
             sys: { id: environmentId },
-            name: environmentId
-          });
+            name: environmentId,
+          })
         } catch (error) {
-          console.error("Error processing environment creation:", error);
-          return new HttpResponse(null, { status: 500 });
+          console.error("Error processing environment creation:", error)
+          return new HttpResponse(null, { status: 500 })
         }
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
   // Delete environment
-  http.delete(
-    "https://api.contentful.com/spaces/:spaceId/environments/:envId",
-    ({ params }) => {
-      const { spaceId, envId } = params;
-      if (spaceId === "test-space-id" && envId !== "non-existent-env") {
-        return new HttpResponse(null, { status: 204 });
-      }
-      return new HttpResponse(null, { status: 404 });
-    },
-  ),
-];
+  http.delete("https://api.contentful.com/spaces/:spaceId/environments/:envId", ({ params }) => {
+    const { spaceId, envId } = params
+    if (spaceId === "test-space-id" && envId !== "non-existent-env") {
+      return new HttpResponse(null, { status: 204 })
+    }
+    return new HttpResponse(null, { status: 404 })
+  }),
+]
 
 // Bulk action handlers
 const bulkActionHandlers = [
@@ -108,93 +102,102 @@ const bulkActionHandlers = [
   http.post(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/bulk_actions/publish",
     async ({ params }) => {
-      const { spaceId, environmentId } = params;
+      const { spaceId, environmentId } = params
       if (spaceId === "test-space-id") {
-        return HttpResponse.json({
-          ...mockBulkAction,
-          sys: {
-            ...mockBulkAction.sys,
-            id: "test-bulk-action-id",
-            status: "created"
-          }
-        }, { status: 201 });
+        return HttpResponse.json(
+          {
+            ...mockBulkAction,
+            sys: {
+              ...mockBulkAction.sys,
+              id: "test-bulk-action-id",
+              status: "created",
+            },
+          },
+          { status: 201 },
+        )
       }
-      return new HttpResponse(null, { status: 404 });
-    }
+      return new HttpResponse(null, { status: 404 })
+    },
   ),
 
   // Create bulk unpublish action
   http.post(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/bulk_actions/unpublish",
     async ({ params }) => {
-      const { spaceId, environmentId } = params;
+      const { spaceId, environmentId } = params
       if (spaceId === "test-space-id") {
-        return HttpResponse.json({
-          ...mockBulkAction,
-          sys: {
-            ...mockBulkAction.sys,
-            id: "test-bulk-action-id",
-            status: "created"
-          }
-        }, { status: 201 });
+        return HttpResponse.json(
+          {
+            ...mockBulkAction,
+            sys: {
+              ...mockBulkAction.sys,
+              id: "test-bulk-action-id",
+              status: "created",
+            },
+          },
+          { status: 201 },
+        )
       }
-      return new HttpResponse(null, { status: 404 });
-    }
+      return new HttpResponse(null, { status: 404 })
+    },
   ),
 
   // Create bulk validate action
   http.post(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/bulk_actions/validate",
     async ({ params }) => {
-      const { spaceId, environmentId } = params;
+      const { spaceId, environmentId } = params
       if (spaceId === "test-space-id") {
-        return HttpResponse.json({
-          ...mockBulkAction,
-          sys: {
-            ...mockBulkAction.sys,
-            id: "test-bulk-action-id",
-            status: "created"
-          }
-        }, { status: 201 });
+        return HttpResponse.json(
+          {
+            ...mockBulkAction,
+            sys: {
+              ...mockBulkAction.sys,
+              id: "test-bulk-action-id",
+              status: "created",
+            },
+          },
+          { status: 201 },
+        )
       }
-      return new HttpResponse(null, { status: 404 });
-    }
+      return new HttpResponse(null, { status: 404 })
+    },
   ),
 
   // Get bulk action status
   http.get(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/bulk_actions/:bulkActionId",
     ({ params }) => {
-      const { spaceId, bulkActionId } = params;
+      const { spaceId, bulkActionId } = params
       if (spaceId === "test-space-id" && bulkActionId === "test-bulk-action-id") {
-        return HttpResponse.json(mockBulkAction);
+        return HttpResponse.json(mockBulkAction)
       }
-      return new HttpResponse(null, { status: 404 });
-    }
+      return new HttpResponse(null, { status: 404 })
+    },
   ),
-];
+]
 
 const assetHandlers = [
   // Upload asset
   http.post(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/assets",
     async ({ request, params }) => {
-      console.log("MSW: Handling asset creation request");
-      const { spaceId } = params;
+      console.log("MSW: Handling asset creation request")
+      const { spaceId } = params
       if (spaceId === "test-space-id") {
         const body = (await request.json()) as {
           fields: {
-            title: { "en-US": string };
-            description?: { "en-US": string };
+            title: { "en-US": string }
+            description?: { "en-US": string }
             file: {
               "en-US": {
-                fileName: string;
-                contentType: string;
-                upload: string;
-              };
-            };
-          };
-        };
+                fileName: string
+                contentType: string
+                upload: string
+              }
+            }
+          }
+        }
 
         return HttpResponse.json({
           sys: {
@@ -203,17 +206,17 @@ const assetHandlers = [
             type: "Asset",
           },
           fields: body.fields,
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
   // Process asset
   http.put(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/assets/:assetId/files/en-US/process",
     ({ params }) => {
-      console.log("MSW: Handling asset processing request");
-      const { spaceId, assetId } = params;
+      console.log("MSW: Handling asset processing request")
+      const { spaceId, assetId } = params
       if (spaceId === "test-space-id" && assetId === "test-asset-id") {
         return HttpResponse.json({
           sys: {
@@ -232,9 +235,9 @@ const assetHandlers = [
               },
             },
           },
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -242,8 +245,8 @@ const assetHandlers = [
   http.get(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/assets/:assetId",
     ({ params }) => {
-      console.log("MSW: Handling get processed asset request");
-      const { spaceId, assetId } = params;
+      console.log("MSW: Handling get processed asset request")
+      const { spaceId, assetId } = params
       if (spaceId === "test-space-id" && assetId === "test-asset-id") {
         return HttpResponse.json({
           sys: {
@@ -263,9 +266,9 @@ const assetHandlers = [
               },
             },
           },
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -273,7 +276,7 @@ const assetHandlers = [
   http.put(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/assets/:assetId",
     ({ params }) => {
-      const { spaceId, assetId } = params;
+      const { spaceId, assetId } = params
       if (spaceId === "test-space-id" && assetId === "test-asset-id") {
         return HttpResponse.json({
           sys: { id: "test-asset-id" },
@@ -281,9 +284,9 @@ const assetHandlers = [
             title: { "en-US": "Updated Asset" },
             description: { "en-US": "Updated Description" },
           },
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -291,11 +294,11 @@ const assetHandlers = [
   http.delete(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/assets/:assetId",
     ({ params }) => {
-      const { spaceId, assetId } = params;
+      const { spaceId, assetId } = params
       if (spaceId === "test-space-id" && assetId === "test-asset-id") {
-        return new HttpResponse(null, { status: 204 });
+        return new HttpResponse(null, { status: 204 })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -303,16 +306,16 @@ const assetHandlers = [
   http.put(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/assets/:assetId/published",
     ({ params }) => {
-      const { spaceId, assetId } = params;
+      const { spaceId, assetId } = params
       if (spaceId === "test-space-id" && assetId === "test-asset-id") {
         return HttpResponse.json({
           sys: {
             id: "test-asset-id",
             publishedVersion: 1,
           },
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -320,25 +323,25 @@ const assetHandlers = [
   http.delete(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/assets/:assetId/published",
     ({ params }) => {
-      const { spaceId, assetId } = params;
+      const { spaceId, assetId } = params
       if (spaceId === "test-space-id" && assetId === "test-asset-id") {
         return HttpResponse.json({
           sys: {
             id: "test-asset-id",
           },
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
-];
+]
 
 const entryHandlers = [
   // Search entries
   http.get(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/entries",
     ({ params, request }) => {
-      const { spaceId } = params;
+      const { spaceId } = params
       if (spaceId === "test-space-id") {
         return HttpResponse.json({
           items: [
@@ -353,9 +356,9 @@ const entryHandlers = [
               },
             },
           ],
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -363,7 +366,7 @@ const entryHandlers = [
   http.get(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/entries/:entryId",
     ({ params }) => {
-      const { spaceId, entryId } = params;
+      const { spaceId, entryId } = params
       if (spaceId === "test-space-id" && entryId === "test-entry-id") {
         return HttpResponse.json({
           sys: {
@@ -374,9 +377,9 @@ const entryHandlers = [
             title: { "en-US": "Test Entry" },
             description: { "en-US": "Test Description" },
           },
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -384,12 +387,12 @@ const entryHandlers = [
   http.post(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/entries",
     async ({ params, request }) => {
-      const { spaceId } = params;
+      const { spaceId } = params
       if (spaceId === "test-space-id") {
-        const contentType = request.headers.get("X-Contentful-Content-Type");
+        const contentType = request.headers.get("X-Contentful-Content-Type")
         const body = (await request.json()) as {
-          fields: Record<string, any>;
-        };
+          fields: Record<string, any>
+        }
 
         return HttpResponse.json({
           sys: {
@@ -404,9 +407,9 @@ const entryHandlers = [
             },
           },
           fields: body.fields,
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -414,20 +417,20 @@ const entryHandlers = [
   http.put(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/entries/:entryId",
     async ({ params, request }) => {
-      const { spaceId, entryId } = params;
+      const { spaceId, entryId } = params
       if (spaceId === "test-space-id" && entryId === "test-entry-id") {
         const body = (await request.json()) as {
-          fields: Record<string, any>;
-        };
+          fields: Record<string, any>
+        }
         return HttpResponse.json({
           sys: {
             id: entryId,
             contentType: { sys: { id: "test-content-type-id" } },
           },
           fields: body.fields,
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -435,11 +438,11 @@ const entryHandlers = [
   http.delete(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/entries/:entryId",
     ({ params }) => {
-      const { spaceId, entryId } = params;
+      const { spaceId, entryId } = params
       if (spaceId === "test-space-id" && entryId === "test-entry-id") {
-        return new HttpResponse(null, { status: 204 });
+        return new HttpResponse(null, { status: 204 })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -447,16 +450,16 @@ const entryHandlers = [
   http.put(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/entries/:entryId/published",
     ({ params }) => {
-      const { spaceId, entryId } = params;
+      const { spaceId, entryId } = params
       if (spaceId === "test-space-id" && entryId === "test-entry-id") {
         return HttpResponse.json({
           sys: {
             id: entryId,
             publishedVersion: 1,
           },
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -464,23 +467,23 @@ const entryHandlers = [
   http.delete(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/entries/:entryId/published",
     ({ params }) => {
-      const { spaceId, entryId } = params;
+      const { spaceId, entryId } = params
       if (spaceId === "test-space-id" && entryId === "test-entry-id") {
         return HttpResponse.json({
           sys: { id: entryId },
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
-];
+]
 
 const contentTypeHandlers = [
   // List content types
   http.get(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/content_types",
     ({ params }) => {
-      const { spaceId } = params;
+      const { spaceId } = params
       if (spaceId === "test-space-id") {
         return HttpResponse.json({
           items: [
@@ -497,9 +500,9 @@ const contentTypeHandlers = [
               ],
             },
           ],
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -507,11 +510,8 @@ const contentTypeHandlers = [
   http.get(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/content_types/:contentTypeId",
     ({ params }) => {
-      const { spaceId, contentTypeId } = params;
-      if (
-        spaceId === "test-space-id" &&
-        contentTypeId === "test-content-type-id"
-      ) {
+      const { spaceId, contentTypeId } = params
+      if (spaceId === "test-space-id" && contentTypeId === "test-content-type-id") {
         return HttpResponse.json({
           sys: { id: "test-content-type-id" },
           name: "Test Content Type",
@@ -523,9 +523,9 @@ const contentTypeHandlers = [
               required: true,
             },
           ],
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -533,19 +533,19 @@ const contentTypeHandlers = [
   http.post(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/content_types",
     async ({ params, request }) => {
-      const { spaceId } = params;
+      const { spaceId } = params
       if (spaceId === "test-space-id") {
         const body = (await request.json()) as {
-          name: string;
+          name: string
           fields: Array<{
-            id: string;
-            name: string;
-            type: string;
-            required?: boolean;
-          }>;
-          description?: string;
-          displayField?: string;
-        };
+            id: string
+            name: string
+            type: string
+            required?: boolean
+          }>
+          description?: string
+          displayField?: string
+        }
 
         return HttpResponse.json({
           sys: { id: "new-content-type-id" },
@@ -553,9 +553,39 @@ const contentTypeHandlers = [
           fields: body.fields,
           description: body.description,
           displayField: body.displayField,
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
+    },
+  ),
+
+  // create content type with ID
+  http.put(
+    "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/content_types/:contentTypeId",
+    async ({ params, request }) => {
+      const { spaceId, contentTypeId } = params
+      if (spaceId === "test-space-id") {
+        const body = (await request.json()) as {
+          name: string
+          fields: Array<{
+            id: string
+            name: string
+            type: string
+            required?: boolean
+          }>
+          description?: string
+          displayField?: string
+        }
+
+        return HttpResponse.json({
+          sys: { id: contentTypeId },
+          name: body.name,
+          fields: body.fields,
+          description: body.description,
+          displayField: body.displayField,
+        })
+      }
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -563,11 +593,8 @@ const contentTypeHandlers = [
   http.put(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/content_types/:contentTypeId/published",
     ({ params }) => {
-      const { spaceId, contentTypeId } = params;
-      if (
-        spaceId === "test-space-id" &&
-        contentTypeId === "test-content-type-id"
-      ) {
+      const { spaceId, contentTypeId } = params
+      if (spaceId === "test-space-id" && contentTypeId === "test-content-type-id") {
         return HttpResponse.json({
           sys: {
             id: contentTypeId,
@@ -583,9 +610,9 @@ const contentTypeHandlers = [
               required: true,
             },
           ],
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -593,22 +620,19 @@ const contentTypeHandlers = [
   http.put(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/content_types/:contentTypeId",
     async ({ params, request }) => {
-      const { spaceId, contentTypeId } = params;
-      if (
-        spaceId === "test-space-id" &&
-        contentTypeId === "test-content-type-id"
-      ) {
+      const { spaceId, contentTypeId } = params
+      if (spaceId === "test-space-id" && contentTypeId === "test-content-type-id") {
         const body = (await request.json()) as {
-          name: string;
+          name: string
           fields: Array<{
-            id: string;
-            name: string;
-            type: string;
-            required?: boolean;
-          }>;
-          description?: string;
-          displayField?: string;
-        };
+            id: string
+            name: string
+            type: string
+            required?: boolean
+          }>
+          description?: string
+          displayField?: string
+        }
 
         return HttpResponse.json({
           sys: { id: contentTypeId },
@@ -616,9 +640,9 @@ const contentTypeHandlers = [
           fields: body.fields,
           description: body.description,
           displayField: body.displayField,
-        });
+        })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
 
@@ -626,17 +650,14 @@ const contentTypeHandlers = [
   http.delete(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/content_types/:contentTypeId",
     ({ params }) => {
-      const { spaceId, contentTypeId } = params;
-      if (
-        spaceId === "test-space-id" &&
-        contentTypeId === "test-content-type-id"
-      ) {
-        return new HttpResponse(null, { status: 204 });
+      const { spaceId, contentTypeId } = params
+      if (spaceId === "test-space-id" && contentTypeId === "test-content-type-id") {
+        return new HttpResponse(null, { status: 204 })
       }
-      return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 404 })
     },
   ),
-];
+]
 
 // Setup MSW Server
 export const server = setupServer(
@@ -645,4 +666,4 @@ export const server = setupServer(
   ...contentTypeHandlers,
   ...entryHandlers,
   ...bulkActionHandlers,
-);
+)


### PR DESCRIPTION
@sfrouse I made some small modification and added tests

--------------------------------------------------------------------


This pull request includes several changes to the `content-type-handlers` and related test files to improve functionality and maintainability. The key updates involve adding a utility function for camel case conversion, modifying handler methods, and updating integration tests accordingly.

### Key Changes:

#### Functionality Improvements:
* Added a new utility function `toCamelCase` to convert strings to camel case in `src/utils/to-camel-case.ts`.
* Updated `contentTypeHandlers` to use `toCamelCase` for `contentTypeId` and changed the method for creating content types to `createWithId` in `src/handlers/content-type-handlers.ts`. [[1]](diffhunk://#diff-a9f353bdf46426488ae3c2676df06be3235ea570011334361c8f71d6ad374a8eR4) [[2]](diffhunk://#diff-a9f353bdf46426488ae3c2676df06be3235ea570011334361c8f71d6ad374a8eR55) [[3]](diffhunk://#diff-a9f353bdf46426488ae3c2676df06be3235ea570011334361c8f71d6ad374a8eL66-R69)

#### Testing Enhancements:
* Modified integration tests to import and use the `toCamelCase` function in `test/integration/content-type-handler.test.ts`.
* Updated test assertions to reflect the changes in content type ID formatting and method updates in `test/integration/content-type-handler.test.ts`. [[1]](diffhunk://#diff-c79d46cb0ad245ad7f94ace6c54baa7e5ea078f317dd7863b9a84670baee14e2L76-R81) [[2]](diffhunk://#diff-c79d46cb0ad245ad7f94ace6c54baa7e5ea078f317dd7863b9a84670baee14e2L106-R155)

#### Code Simplification:
* Refactored `test/msw-setup.ts` to improve readability by removing unnecessary semicolons and ensuring consistent formatting. [[1]](diffhunk://#diff-e6d3859b6e0a7a542fed2a55acda2dbe8b9d557b7d1de5591809177300f9437bL1-R15) [[2]](diffhunk://#diff-e6d3859b6e0a7a542fed2a55acda2dbe8b9d557b7d1de5591809177300f9437bL28-R45) [[3]](diffhunk://#diff-e6d3859b6e0a7a542fed2a55acda2dbe8b9d557b7d1de5591809177300f9437bL56-R200) [[4]](diffhunk://#diff-e6d3859b6e0a7a542fed2a55acda2dbe8b9d557b7d1de5591809177300f9437bL206-R219) [[5]](diffhunk://#diff-e6d3859b6e0a7a542fed2a55acda2dbe8b9d557b7d1de5591809177300f9437bL235-R249) [[6]](diffhunk://#diff-e6d3859b6e0a7a542fed2a55acda2dbe8b9d557b7d1de5591809177300f9437bL266-R344) [[7]](diffhunk://#diff-e6d3859b6e0a7a542fed2a55acda2dbe8b9d557b7d1de5591809177300f9437bL356-R369)