### PR TITLE
Improve `list_content_types` tool

### DIFF
--- a/src/handlers/content-type-handlers.ts
+++ b/src/handlers/content-type-handlers.ts
@@ -2,21 +2,30 @@
 import { getContentfulClient } from "../config/client.js"
 import { ContentTypeProps, CreateContentTypeProps } from "contentful-management"
 import { toCamelCase } from "../utils/to-camel-case.js"
+import {summarizeData} from "../utils/summarizer.js";
 
 export const contentTypeHandlers = {
-  listContentTypes: async (args: { spaceId: string; environmentId: string }) => {
+  listContentTypes: async (args: { spaceId: string; environmentId: string, limit?: number, skip?: number }) => {
     const spaceId = process.env.SPACE_ID || args.spaceId
     const environmentId = process.env.ENVIRONMENT_ID || args.environmentId
+    const { limit = 3, skip = 0 } = args
 
     const params = {
       spaceId,
       environmentId,
+      limit,
+      skip,
     }
 
     const contentfulClient = await getContentfulClient()
     const contentTypes = await contentfulClient.contentType.getMany(params)
+    const summarized = summarizeData(contentTypes, {
+      maxItems: limit,
+      remainingMessage: "To see more content types, please ask me to retrieve the next page.",
+    })
+
     return {
-      content: [{ type: "text", text: JSON.stringify(contentTypes, null, 2) }],
+      content: [{ type: "text", text: JSON.stringify(summarized, null, 2) }],
     }
   },
   getContentType: async (args: {

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -293,8 +293,7 @@ export const getContentTypeTools = () => {
   return {
     LIST_CONTENT_TYPES: {
       name: "list_content_types",
-      description:
-        "List content types in a space. Returns a maximum of 10 items per request. Use skip parameter to paginate through results.",
+      description: "List content types by space and environment, with paginated results. Returns a maximum of 20 items per request. Use the skip and limit parameters to paginate through results. Information about the total and remaining items is also provided.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
@@ -302,7 +301,7 @@ export const getContentTypeTools = () => {
             type: "number",
             default: 10,
             maximum: 20,
-            description: "Maximum number of items to return (max: 3)",
+            description: "Maximum number of items to return (max: 20)",
           },
           skip: {
             type: "number",

--- a/test/integration/content-type-handler.test.ts
+++ b/test/integration/content-type-handler.test.ts
@@ -26,6 +26,20 @@ describe("Content Type Handlers Integration Tests", () => {
       expect(contentTypes.items[0]).to.have.nested.property("sys.id", "test-content-type-id")
       expect(contentTypes.items[0]).to.have.property("name", "Test Content Type")
     })
+
+    it("should summarize paginated data", async () => {
+      const result = await contentTypeHandlers.listContentTypes({
+        spaceId: testSpaceId,
+        limit: 10,
+      })
+      expect(result).to.have.property("content").that.is.an("array")
+      expect(result.content).to.have.lengthOf(1)
+      const contentTypes = JSON.parse(result.content[0].text)
+      expect(contentTypes).to.have.property("total", 100)
+      expect(contentTypes).to.have.property("showing", 10)
+      expect(contentTypes).to.have.property("remaining", 90)
+      expect(contentTypes).to.have.property("message", "To see more content types, please ask me to retrieve the next page.")
+    })
   })
 
   describe("getContentType", () => {

--- a/test/msw-setup.ts
+++ b/test/msw-setup.ts
@@ -483,23 +483,29 @@ const contentTypeHandlers = [
   http.get(
     "https://api.contentful.com/spaces/:spaceId/environments/:environmentId/content_types",
     ({ params }) => {
-      const { spaceId } = params
+      const { limit, skip, spaceId } = params
       if (spaceId === "test-space-id") {
-        return HttpResponse.json({
-          items: [
+        const total = 100 // Assume there are 100 content types in total
+        const start = parseInt(Array.isArray(skip) ? skip[0] : skip) || 0
+        const end = start + parseInt(Array.isArray(limit) ? limit[0] : limit) || 20
+        const items = Array.from({ length: Math.min(end, total) - start }, (_, index) => ({
+          sys: { id: index === 0 ? "test-content-type-id" : `test-content-type-id-${start + index}` },
+          name: index === 0 ? "Test Content Type" : `Test Content Type ${start + index}`,
+          fields: [
             {
-              sys: { id: "test-content-type-id" },
-              name: "Test Content Type",
-              fields: [
-                {
-                  id: "title",
-                  name: "Title",
-                  type: "Text",
-                  required: true,
-                },
-              ],
+              id: "title",
+              name: "Title",
+              type: "Text",
+              required: true,
             },
           ],
+        }))
+
+        return HttpResponse.json({
+          total,
+          skip,
+          limit,
+          items,
         })
       }
       return new HttpResponse(null, { status: 404 })


### PR DESCRIPTION
I spent some time experimenting with this MCP (which is great btw!) this week. One thing I noticed was that when I asked it to give me the total number of content types in a space, the model would get in to a continuous loop, fetching the same set of content types and never returning a result. I first attempted to fix this by improving the description, but I always got the same results.

Finally, I looked at the handler and noticed that it didn't use the limit or skip parameters when fetching from the API. To address this, I decided to leverage the `summarizeData` function that was used by other listing tools. On testing, this produced much better results, allowing me to easily get the total number of content types, and even find content types IDs by name and other operations.