### PR TITLE
fix: fetch type and entry to merge fields before updating on API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -300,3 +300,5 @@ cython_debug/
 #.idea/
 .aider*
 Cntfl-Readme.md
+
+**/.claude/settings.local.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ivotoby/contentful-management-mcp-server",
-  "version": "2.0.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivotoby/contentful-management-mcp-server",
-      "version": "2.0.0",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/node-apps-toolkit": "^3.13.0",

--- a/src/handlers/entry-handlers.ts
+++ b/src/handlers/entry-handlers.ts
@@ -113,8 +113,24 @@ export const entryHandlers = {
     const contentfulClient = await getContentfulClient()
     const currentEntry = await contentfulClient.entry.get(params)
 
+    // Merge existing fields with updated fields to ensure all fields are present
+    const mergedFields = { ...currentEntry.fields }
+
+    // Apply updates to each field and locale
+    for (const fieldId in args.fields) {
+      if (Object.prototype.hasOwnProperty.call(args.fields, fieldId)) {
+        // If the field exists in currentEntry, merge the locale values
+        if (mergedFields[fieldId]) {
+          mergedFields[fieldId] = { ...mergedFields[fieldId], ...args.fields[fieldId] }
+        } else {
+          // If it's a new field, add it
+          mergedFields[fieldId] = args.fields[fieldId]
+        }
+      }
+    }
+
     const entryProps: EntryProps = {
-      fields: args.fields,
+      fields: mergedFields,
       sys: currentEntry.sys,
     }
 

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -76,7 +76,7 @@ export const getEntryTools = () => {
     CREATE_ENTRY: {
       name: "create_entry",
       description:
-        "Create a new entry in Contentful, before executing this function, you need to know the contentTypeId (not the content type NAME) and the fields of that contentType, you can get the fields definition by using the GET_CONTENT_TYPE tool. ",
+        "Create a new entry in Contentful. Before executing this function, you need to know the contentTypeId (not the content type NAME) and the fields of that contentType. You can get the fields definition by using the GET_CONTENT_TYPE tool. IMPORTANT: All field values MUST include a locale key (e.g., 'en-US') for each value, like: { title: { 'en-US': 'My Title' } }. Every field in Contentful requires a locale even for single-language content.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
@@ -84,7 +84,10 @@ export const getEntryTools = () => {
             type: "string",
             description: "The ID of the content type for the new entry",
           },
-          fields: { type: "object", description: "The fields of the entry" },
+          fields: {
+            type: "object",
+            description: "The fields of the entry with localized values. Example: { title: { 'en-US': 'My Title' }, description: { 'en-US': 'My Description' } }"
+          },
         },
         required: ["contentTypeId", "fields"],
       }),
@@ -103,12 +106,15 @@ export const getEntryTools = () => {
     UPDATE_ENTRY: {
       name: "update_entry",
       description:
-        "Update an existing entry. The handler will merge your field updates with the existing entry fields, so you only need to provide the fields and locales you want to change.",
+        "Update an existing entry. The handler will merge your field updates with the existing entry fields, so you only need to provide the fields and locales you want to change. IMPORTANT: All field values MUST include a locale key (e.g., 'en-US') for each value, like: { title: { 'en-US': 'My Updated Title' } }. Every field in Contentful requires a locale even for single-language content.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
           entryId: { type: "string" },
-          fields: { type: "object" },
+          fields: {
+            type: "object",
+            description: "The fields to update with localized values. Example: { title: { 'en-US': 'My Updated Title' } }"
+          },
         },
         required: ["entryId", "fields"],
       }),

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -103,7 +103,7 @@ export const getEntryTools = () => {
     UPDATE_ENTRY: {
       name: "update_entry",
       description:
-        "Update an existing entry, very important: always send all field values and all values related to locales, also the fields values that have not been updated",
+        "Update an existing entry. The handler will merge your field updates with the existing entry fields, so you only need to provide the fields and locales you want to change.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
@@ -418,7 +418,8 @@ export const getContentTypeTools = () => {
     },
     UPDATE_CONTENT_TYPE: {
       name: "update_content_type",
-      description: "Update an existing content type",
+      description:
+        "Update an existing content type. The handler will merge your field updates with existing content type data, so you only need to provide the fields and properties you want to change.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
@@ -431,7 +432,7 @@ export const getContentTypeTools = () => {
           description: { type: "string" },
           displayField: { type: "string" },
         },
-        required: ["contentTypeId", "name", "fields"],
+        required: ["contentTypeId", "fields"],
       }),
     },
     DELETE_CONTENT_TYPE: {

--- a/test/unit/content-type-handler-merge.test.ts
+++ b/test/unit/content-type-handler-merge.test.ts
@@ -1,0 +1,267 @@
+import { expect, vi, describe, it, beforeEach } from "vitest"
+import { contentTypeHandlers } from "../../src/handlers/content-type-handlers.js"
+
+// Define constants
+const TEST_CONTENT_TYPE_ID = "test-content-type-id"
+const TEST_SPACE_ID = "test-space-id"
+const TEST_ENV_ID = "master"
+
+// Mock the Contentful client for testing the merge logic
+vi.mock("../../src/config/client.js", () => {
+  return {
+    getContentfulClient: vi.fn().mockImplementation(() => {
+      // Create mock content type inside the function implementation
+      const mockContentType = {
+        sys: { id: TEST_CONTENT_TYPE_ID, version: 1 },
+        name: "Original Content Type",
+        description: "Original description",
+        displayField: "title",
+        fields: [
+          {
+            id: "title",
+            name: "Title",
+            type: "Text",
+            required: true,
+            validations: [{ size: { max: 100 } }]
+          },
+          {
+            id: "description",
+            name: "Description",
+            type: "Text",
+            required: false
+          },
+          {
+            id: "image",
+            name: "Image",
+            type: "Link",
+            linkType: "Asset",
+            required: false
+          },
+          {
+            id: "tags",
+            name: "Tags",
+            type: "Array",
+            items: {
+              type: "Symbol"
+            }
+          }
+        ]
+      }
+
+      return {
+        contentType: {
+          get: vi.fn().mockResolvedValue(mockContentType),
+          update: vi.fn().mockImplementation((params, contentTypeProps) => {
+            // Return a merged content type that simulates the updated fields
+            return Promise.resolve({
+              sys: { id: params.contentTypeId, version: 2 },
+              name: contentTypeProps.name,
+              description: contentTypeProps.description,
+              displayField: contentTypeProps.displayField,
+              fields: contentTypeProps.fields
+            })
+          })
+        }
+      }
+    })
+  }
+})
+
+describe("Content Type Handler Merge Logic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should use existing name when name is not provided", async () => {
+    // Setup - update without providing name
+    const updateData = {
+      spaceId: TEST_SPACE_ID,
+      environmentId: TEST_ENV_ID,
+      contentTypeId: TEST_CONTENT_TYPE_ID,
+      fields: [
+        {
+          id: "title",
+          name: "Title",
+          type: "Text",
+          required: true,
+          validations: [{ size: { max: 100 } }]
+        },
+        {
+          id: "description",
+          name: "Description",
+          type: "Text",
+          required: false
+        },
+        {
+          id: "image",
+          name: "Image",
+          type: "Link",
+          linkType: "Asset",
+          required: false
+        },
+        {
+          id: "tags",
+          name: "Tags",
+          type: "Array",
+          items: {
+            type: "Symbol"
+          }
+        }
+      ],
+      description: "Updated description"
+    }
+
+    // Execute
+    const result = await contentTypeHandlers.updateContentType(updateData)
+    
+    // Parse the result
+    const updatedContentType = JSON.parse(result.content[0].text)
+    
+    // Assert - should keep the original name but update description
+    expect(updatedContentType.name).toEqual("Original Content Type")
+    expect(updatedContentType.description).toEqual("Updated description")
+  })
+
+  it("should preserve field metadata when updating fields", async () => {
+    // Setup - update with simplified field definition that's missing metadata
+    const updateData = {
+      spaceId: TEST_SPACE_ID,
+      environmentId: TEST_ENV_ID,
+      contentTypeId: TEST_CONTENT_TYPE_ID,
+      fields: [
+        {
+          id: "title",
+          name: "New Title Name",
+          type: "Text"
+          // Intentionally missing required, validations, etc.
+        },
+        {
+          id: "image",
+          name: "Updated Image",
+          type: "Link"
+          // Missing linkType
+        },
+        {
+          id: "tags",
+          name: "Updated Tags",
+          type: "Array"
+          // Missing items definition
+        }
+      ]
+    }
+
+    // Execute
+    const result = await contentTypeHandlers.updateContentType(updateData)
+    
+    // Parse the result
+    const updatedContentType = JSON.parse(result.content[0].text)
+    
+    // Assert - fields should be updated but metadata should be preserved
+    const titleField = updatedContentType.fields.find(f => f.id === "title")
+    expect(titleField.name).toEqual("New Title Name") // Updated
+    expect(titleField.required).toEqual(true) // Preserved from original
+    expect(titleField.validations).toEqual([{ size: { max: 100 } }]) // Preserved from original
+    
+    const imageField = updatedContentType.fields.find(f => f.id === "image")
+    expect(imageField.name).toEqual("Updated Image") // Updated
+    expect(imageField.linkType).toEqual("Asset") // Preserved from original
+    
+    const tagsField = updatedContentType.fields.find(f => f.id === "tags")
+    expect(tagsField.name).toEqual("Updated Tags") // Updated
+    expect(tagsField.items).toEqual({ type: "Symbol" }) // Preserved from original
+  })
+
+  it("should handle adding new fields", async () => {
+    // Define the original and a new field
+    const originalFields = [
+      {
+        id: "title",
+        name: "Title",
+        type: "Text",
+        required: true,
+        validations: [{ size: { max: 100 } }]
+      },
+      {
+        id: "description",
+        name: "Description",
+        type: "Text",
+        required: false
+      },
+      {
+        id: "image",
+        name: "Image",
+        type: "Link",
+        linkType: "Asset",
+        required: false
+      },
+      {
+        id: "tags",
+        name: "Tags",
+        type: "Array",
+        items: {
+          type: "Symbol"
+        }
+      }
+    ]
+    
+    const newField = {
+      id: "newField",
+      name: "New Field",
+      type: "Boolean",
+      required: false
+    }
+    
+    // Setup - add a new field
+    const updateData = {
+      spaceId: TEST_SPACE_ID,
+      environmentId: TEST_ENV_ID,
+      contentTypeId: TEST_CONTENT_TYPE_ID,
+      fields: [...originalFields, newField]
+    }
+
+    // Execute
+    const result = await contentTypeHandlers.updateContentType(updateData)
+    
+    // Parse the result
+    const updatedContentType = JSON.parse(result.content[0].text)
+    
+    // Assert - should have all original fields plus the new one
+    expect(updatedContentType.fields.length).toEqual(5) // 4 original + 1 new
+    const addedField = updatedContentType.fields.find(f => f.id === "newField")
+    expect(addedField).toEqual({
+      id: "newField",
+      name: "New Field",
+      type: "Boolean",
+      required: false
+    })
+  })
+
+  it("should handle when no fields are provided", async () => {
+    // Setup - update without providing fields, should use existing fields
+    const updateData = {
+      spaceId: TEST_SPACE_ID,
+      environmentId: TEST_ENV_ID,
+      contentTypeId: TEST_CONTENT_TYPE_ID,
+      name: "Updated Content Type Name"
+    }
+
+    // Execute
+    const result = await contentTypeHandlers.updateContentType(updateData)
+    
+    // Parse the result
+    const updatedContentType = JSON.parse(result.content[0].text)
+    
+    // Assert - should use existing fields but updated name
+    expect(updatedContentType.name).toEqual("Updated Content Type Name")
+    expect(updatedContentType.fields.length).toEqual(4) // All 4 original fields should be preserved
+    
+    // Check that all original fields are preserved
+    const titleField = updatedContentType.fields.find(f => f.id === "title")
+    expect(titleField).toBeDefined()
+    expect(titleField.name).toEqual("Title")
+    
+    const descriptionField = updatedContentType.fields.find(f => f.id === "description")
+    expect(descriptionField).toBeDefined()
+    expect(descriptionField.name).toEqual("Description")
+  })
+})

--- a/test/unit/entry-handler-merge.test.ts
+++ b/test/unit/entry-handler-merge.test.ts
@@ -1,0 +1,137 @@
+import { expect, vi, describe, it, beforeEach } from "vitest"
+import { entryHandlers } from "../../src/handlers/entry-handlers.js"
+
+// Define test constants 
+const TEST_ENTRY_ID = "test-entry-id"
+const TEST_SPACE_ID = "test-space-id"
+const TEST_ENV_ID = "master"
+
+// Move vi.mock call to top level - this gets hoisted automatically
+vi.mock("../../src/config/client.js", () => {
+  return {
+    getContentfulClient: vi.fn().mockImplementation(() => {
+      // Create mock entry when the function is called
+      const mockEntry = {
+        sys: { id: TEST_ENTRY_ID, version: 1 },
+        fields: {
+          title: { "en-US": "Original Title" },
+          description: { "en-US": "Original Description" },
+          tags: { "en-US": ["tag1", "tag2"] }
+        }
+      }
+
+      return {
+        entry: {
+          get: vi.fn().mockResolvedValue(mockEntry),
+          update: vi.fn().mockImplementation((params, entryProps) => {
+            // Return a merged entry that simulates the updated fields
+            return Promise.resolve({
+              sys: { id: params.entryId, version: 2 },
+              fields: entryProps.fields
+            })
+          })
+        }
+      }
+    })
+  }
+})
+
+describe("Entry Handler Merge Logic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should merge existing fields with update fields when only partial update is provided", async () => {
+    // Setup - just update the title but not other fields
+    const updateData = {
+      spaceId: TEST_SPACE_ID,
+      environmentId: TEST_ENV_ID,
+      entryId: TEST_ENTRY_ID,
+      fields: {
+        title: { "en-US": "Updated Title" }
+      }
+    }
+
+    // Execute
+    const result = await entryHandlers.updateEntry(updateData)
+    
+    // Parse the result
+    const updatedEntry = JSON.parse(result.content[0].text)
+    
+    // Assert - should have updated title but kept original description and tags
+    expect(updatedEntry.fields.title["en-US"]).toEqual("Updated Title")
+    expect(updatedEntry.fields.description["en-US"]).toEqual("Original Description")
+    expect(updatedEntry.fields.tags["en-US"]).toEqual(["tag1", "tag2"])
+  })
+
+  it("should handle updates to nested locale fields", async () => {
+    // Setup - update a specific locale but not others
+    const updateData = {
+      spaceId: TEST_SPACE_ID,
+      environmentId: TEST_ENV_ID,
+      entryId: TEST_ENTRY_ID,
+      fields: {
+        title: { 
+          "de-DE": "Deutscher Titel" // Add a new locale
+        }
+      }
+    }
+
+    // Execute
+    const result = await entryHandlers.updateEntry(updateData)
+    
+    // Parse the result
+    const updatedEntry = JSON.parse(result.content[0].text)
+    
+    // Assert - should merge the locales in the title field
+    expect(updatedEntry.fields.title["en-US"]).toEqual("Original Title") // Kept original locale
+    expect(updatedEntry.fields.title["de-DE"]).toEqual("Deutscher Titel") // Added new locale
+    expect(updatedEntry.fields.description["en-US"]).toEqual("Original Description") // Kept other fields
+  })
+
+  it("should handle adding a new field", async () => {
+    // Setup - add a completely new field
+    const updateData = {
+      spaceId: TEST_SPACE_ID,
+      environmentId: TEST_ENV_ID,
+      entryId: TEST_ENTRY_ID,
+      fields: {
+        newField: { "en-US": "New Field Value" }
+      }
+    }
+
+    // Execute
+    const result = await entryHandlers.updateEntry(updateData)
+    
+    // Parse the result
+    const updatedEntry = JSON.parse(result.content[0].text)
+    
+    // Assert - should have original fields plus the new field
+    expect(updatedEntry.fields.title["en-US"]).toEqual("Original Title")
+    expect(updatedEntry.fields.description["en-US"]).toEqual("Original Description")
+    expect(updatedEntry.fields.newField["en-US"]).toEqual("New Field Value")
+  })
+
+  it("should handle updating an array field", async () => {
+    // Setup - update the tags array
+    const updateData = {
+      spaceId: TEST_SPACE_ID,
+      environmentId: TEST_ENV_ID,
+      entryId: TEST_ENTRY_ID,
+      fields: {
+        tags: { "en-US": ["tag1", "tag2", "tag3"] } // Add tag3
+      }
+    }
+
+    // Execute
+    const result = await entryHandlers.updateEntry(updateData)
+    
+    // Parse the result
+    const updatedEntry = JSON.parse(result.content[0].text)
+    
+    // Assert - should have updated tags but kept other fields
+    expect(updatedEntry.fields.title["en-US"]).toEqual("Original Title")
+    expect(updatedEntry.fields.description["en-US"]).toEqual("Original Description")
+    expect(updatedEntry.fields.tags["en-US"]).toEqual(["tag1", "tag2", "tag3"])
+  })
+})


### PR DESCRIPTION
This pull request introduces enhancements to the `contentTypeHandlers` and `entryHandlers` in the Contentful integration, focusing on improving field merging logic, preserving metadata, and supporting partial updates. It also updates related tool descriptions and adds comprehensive unit tests to ensure correctness.

### Enhancements to Field Handling Logic:
* Updated `contentTypeHandlers` to support merging new fields with existing ones while preserving metadata such as validations, required flags, `linkType`, and `items`. This ensures no important metadata is lost during updates. (`src/handlers/content-type-handlers.ts`, [src/handlers/content-type-handlers.tsR96-R133](diffhunk://#diff-a9f353bdf46426488ae3c2676df06be3235ea570011334361c8f71d6ad374a8eR96-R133))
* Modified `entryHandlers` to merge existing fields with updated fields, allowing partial updates without overwriting unchanged fields. This includes handling nested locale fields and array updates. (`src/handlers/entry-handlers.ts`, [src/handlers/entry-handlers.tsR116-R133](diffhunk://#diff-a970835e531d11d284d2af8f7014cb3d30bad3c2df7d009c11931a0f6ba9da98R116-R133))

### Updates to Tool Descriptions:
* Clarified the requirements for localized field values in `CREATE_ENTRY` and `UPDATE_ENTRY` tools, emphasizing the need for locale keys in all field values. (`src/types/tools.ts`, [[1]](diffhunk://#diff-950fb07c3d305fe53dd7d19370a42bbdc70f3e3bcc1845c6b2b1501696b9a22dL79-R90) [[2]](diffhunk://#diff-950fb07c3d305fe53dd7d19370a42bbdc70f3e3bcc1845c6b2b1501696b9a22dL106-R117)
* Updated the `UPDATE_CONTENT_TYPE` tool description to specify that only the fields and properties to be changed need to be provided. Removed the requirement for `name` in the input schema. (`src/types/tools.ts`, [[1]](diffhunk://#diff-950fb07c3d305fe53dd7d19370a42bbdc70f3e3bcc1845c6b2b1501696b9a22dL421-R428) [[2]](diffhunk://#diff-950fb07c3d305fe53dd7d19370a42bbdc70f3e3bcc1845c6b2b1501696b9a22dL434-R441)

### Unit Tests for Merge Logic:
* Added unit tests for `contentTypeHandlers` to validate field merging, metadata preservation, adding new fields, and handling cases where no fields are provided. (`test/unit/content-type-handler-merge.test.ts`, [test/unit/content-type-handler-merge.test.tsR1-R267](diffhunk://#diff-6e3116c8de3c695b83b0152bee4dbf3fbdb86f48385d24c33a07cc130be21d87R1-R267))
* Added unit tests for `entryHandlers` to ensure proper merging of existing and updated fields, handling of nested locales, adding new fields, and updating array fields. (`test/unit/entry-handler-merge.test.ts`, [test/unit/entry-handler-merge.test.tsR1-R137](diffhunk://#diff-5150a57efe34aeb2844cee7ce4504fc72e5bc9977e749f21bb3c9c5ff2e44704R1-R137))