### PR TITLE
feat(comments): add support for threaded comments 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An MCP server implementation that integrates with Contentful's Content Managemen
 ## Features
 
 - **Content Management**: Full CRUD operations for entries and assets
-- **Comment Management**: Create, retrieve, and manage comments on entries with support for both plain-text and rich-text formats
+- **Comment Management**: Create, retrieve, and manage comments on entries with support for both plain-text and rich-text formats, including threaded conversations
 - **Space Management**: Create, update, and manage spaces and environments
 - **Content Types**: Manage content type definitions
 - **Localization**: Support for multiple locales
@@ -62,10 +62,25 @@ These bulk operation tools are ideal for content migrations, mass updates, or ba
 ### Comment Management
 
 - **get_comments**: Retrieve comments for an entry with filtering by status (active, resolved, all)
-- **create_comment**: Create new comments on entries with support for both plain-text and rich-text formats
+- **create_comment**: Create new comments on entries with support for both plain-text and rich-text formats. Supports threaded conversations by providing a parent comment ID to reply to existing comments
 - **get_single_comment**: Retrieve a specific comment by its ID for an entry
 - **delete_comment**: Delete a specific comment from an entry
 - **update_comment**: Update existing comments with new body content or status changes
+
+#### Threaded Comments
+
+Comments support threading functionality to enable structured conversations and work around the 512-character limit:
+
+- **Reply to Comments**: Use the `parent` parameter in `create_comment` to reply to an existing comment
+- **Threaded Conversations**: Build conversation trees by replying to specific comments
+- **Extended Discussions**: Work around the 512-character limit by creating threaded replies to continue longer messages
+- **Conversation Context**: Maintain context in discussions by organizing related comments in threads
+
+Example usage:
+
+1. Create a main comment: `create_comment` with `entryId`, `body`, and `status`
+2. Reply to that comment: `create_comment` with `entryId`, `body`, `status`, and `parent` (the ID of the comment you're replying to)
+3. Continue the thread: Reply to any comment in the thread by using its ID as the `parent`
 
 ### Bulk Operations
 

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -871,7 +871,7 @@ export const getCommentTools = () => {
     CREATE_COMMENT: {
       name: "create_comment",
       description:
-        "Create a new comment on an entry. The comment will be created with the specified body and status.",
+        "Create a new comment on an entry. The comment will be created with the specified body and status. To create a threaded conversation (reply to an existing comment), provide the parent comment ID. This allows you to work around the 512-character limit by creating threaded replies.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
@@ -881,13 +881,18 @@ export const getCommentTools = () => {
           },
           body: {
             type: "string",
-            description: "The content of the comment",
+            description: "The content of the comment (max 512 characters)",
           },
           status: {
             type: "string",
             enum: ["active"],
             default: "active",
             description: "The status of the comment",
+          },
+          parent: {
+            type: "string",
+            description:
+              "Optional ID of the parent comment to reply to. Use this to create threaded conversations or to continue longer messages by replying to your own comments.",
           },
         },
         required: ["entryId", "body"],


### PR DESCRIPTION
This pull request introduces support for threaded comments in the Contentful integration, enabling structured conversations and extended discussions by replying to specific comments. The changes include updates to the documentation, API handlers, and type definitions to accommodate this new functionality.

### Documentation Updates:
* Updated `README.md` to include threaded comment functionality in the features list and detailed usage examples, such as replying to comments and building conversation trees. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R84)

### API Handler Enhancements:
* Modified `create_comment` handler in `src/handlers/comment-handlers.ts` to accept an optional `parent` parameter for specifying the parent comment ID, enabling threaded replies. Adjusted the `baseParams` and `commentData` to include `parentCommentId` when provided. [[1]](diffhunk://#diff-6bda9c420c824f0739196e34b5e15f395842bec24a8e3174f9e002d6e2c64baaR72) [[2]](diffhunk://#diff-6bda9c420c824f0739196e34b5e15f395842bec24a8e3174f9e002d6e2c64baaL81-R106)

### Type Definition Updates:
* Updated `src/types/tools.ts` to include a `parent` field in the `CREATE_COMMENT` input schema, with a description explaining its use for creating threaded conversations or extending messages beyond the 512-character limit. [[1]](diffhunk://#diff-950fb07c3d305fe53dd7d19370a42bbdc70f3e3bcc1845c6b2b1501696b9a22dL874-R874) [[2]](diffhunk://#diff-950fb07c3d305fe53dd7d19370a42bbdc70f3e3bcc1845c6b2b1501696b9a22dL884-R896)