### PR TITLE
feat(comment-handlers): add pagination support with limit and skip to comments

### DIFF
--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -844,7 +844,7 @@ export const getCommentTools = () => {
     GET_COMMENTS: {
       name: "get_comments",
       description:
-        "Retrieve comments for an entry. Returns comments with their status and body content.",
+        "Retrieve comments for an entry with pagination support. Returns comments with their status and body content.",
       inputSchema: getSpaceEnvProperties({
         type: "object",
         properties: {
@@ -863,6 +863,19 @@ export const getCommentTools = () => {
             enum: ["active", "resolved", "all"],
             default: "active",
             description: "Filter comments by status",
+          },
+          limit: {
+            type: "number",
+            default: 10,
+            minimum: 1,
+            maximum: 100,
+            description: "Maximum number of comments to return (1-100, default: 10)",
+          },
+          skip: {
+            type: "number",
+            default: 0,
+            minimum: 0,
+            description: "Number of comments to skip for pagination (default: 0)",
           },
         },
         required: ["entryId"],


### PR DESCRIPTION


refactor(comment-handlers): remove summarizeData usage and replace with manual pagination logic

test(comment-handlers): add integration tests for pagination with limit and skip parameters

docs(tools): update get_comments description to include pagination support

refactor(comment-handlers): simplify response text formatting by removing redundant messages