### PR TITLE
fix(build): fix buffer-equal-constant-time not compatible with node25

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,4 +1,14 @@
 import * as esbuild from "esbuild";
+
+// SlowBuffer polyfill - buffer-equal-constant-time (dependency of jsonwebtoken
+// used by @contentful/node-apps-toolkit) accesses SlowBuffer.prototype which was
+// removed from Node.js. This polyfill must run before any require() calls.
+const slowBufferPolyfill = `
+import { Buffer as _Buffer } from 'buffer';
+import _bufferModule from 'buffer';
+if (!_bufferModule.SlowBuffer) { _bufferModule.SlowBuffer = _Buffer; }
+`;
+
 await esbuild.build({
   entryPoints: ["./src/index.ts"],
   bundle: true,
@@ -7,6 +17,6 @@ await esbuild.build({
   outfile: "./dist/bundle.js",
   target: "node18",
   banner: {
-    js: `import { createRequire } from 'module';const require = createRequire(import.meta.url);`,
+    js: `import { createRequire } from 'module';const require = createRequire(import.meta.url);${slowBufferPolyfill}`,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1173,6 +1173,7 @@
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2104,6 +2105,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.16.tgz",
       "integrity": "sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -2265,6 +2267,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2591,6 +2594,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4062,6 +4066,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4520,6 +4525,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6157,6 +6163,7 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10575,6 +10582,7 @@
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -11507,6 +11515,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11737,6 +11746,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11804,6 +11814,7 @@
       "integrity": "sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.22.0",
         "@typescript-eslint/types": "8.22.0",
@@ -12162,6 +12173,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12707,6 +12719,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12968,6 +12981,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,13 @@
 import { beforeAll, expect } from 'vitest';
 import dotenv from "dotenv";
+import buffer from "buffer";
+
+// Polyfill SlowBuffer which was removed from Node.js but is still required
+// by buffer-equal-constant-time (a dependency of jsonwebtoken used by
+// @contentful/node-apps-toolkit)
+if (!buffer.SlowBuffer) {
+  (buffer as typeof buffer & { SlowBuffer: typeof Buffer }).SlowBuffer = Buffer;
+}
 
 // Load environment variables from .env file
 dotenv.config();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures runtime compatibility with Node 25 by restoring access to `SlowBuffer` required by transitive deps.
> 
> - Injects a `SlowBuffer` polyfill via esbuild `banner.js` in `build.js` so it runs before any `require()` calls
> - Adds the same `SlowBuffer` polyfill to `test/setup.ts` for the test environment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9938b069f8d13aff372cafd65d5457a00aedb762. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->