### PR TITLE
feat: add DISABLE_AI_ACTIONS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ These variables can also be set as arguments
 - `ENABLE_HTTP_SERVER` / `--http`: Set to "true" to enable HTTP/SSE mode
 - `HTTP_PORT` / `--port`: Port for HTTP server (default: 3000)
 - `HTTP_HOST` / `--http-host`: Host for HTTP server (default: localhost)
+- `DISABLE_AI_ACTIONS`: Set to "true" to disable fetching AI Actions on startup (useful if you don't have access to this feature)
 
 ### Space and Environment Scoping
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,6 +260,11 @@ async function handleAiActionInvocation(actionId: string, args: Record<string, u
 // Functions to initialize and refresh AI Actions
 async function loadAiActions() {
   try {
+    // Skip AI Actions loading if disabled
+    if (process.env.DISABLE_AI_ACTIONS === "true") {
+      return
+    }
+
     // First, clear the cache to avoid duplicates
     aiActionToolContext.clearCache()
 

--- a/src/transports/streamable-http.ts
+++ b/src/transports/streamable-http.ts
@@ -410,6 +410,11 @@ export class StreamableHttpServer {
    */
   private async loadAiActions(): Promise<void> {
     try {
+      // Skip AI Actions loading if disabled
+      if (process.env.DISABLE_AI_ACTIONS === "true") {
+        return
+      }
+
       // First, clear the cache to avoid duplicates
       this.aiActionToolContext.clearCache()
 

--- a/test/unit/disable-ai-actions.test.ts
+++ b/test/unit/disable-ai-actions.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { aiActionHandlers } from "../../src/handlers/ai-action-handlers"
+
+// Mock the AI Actions handlers
+vi.mock("../../src/handlers/ai-action-handlers", () => ({
+  aiActionHandlers: {
+    listAiActions: vi.fn(),
+  },
+}))
+
+// Mock the AI Actions client
+vi.mock("../../src/config/ai-actions-client", () => ({
+  aiActionsClient: {
+    listAiActions: vi.fn(),
+  },
+}))
+
+describe("DISABLE_AI_ACTIONS environment variable", () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it("should skip AI Actions loading when DISABLE_AI_ACTIONS is set to 'true'", async () => {
+    process.env.DISABLE_AI_ACTIONS = "true"
+    process.env.SPACE_ID = "test-space"
+    process.env.ENVIRONMENT_ID = "master"
+
+    // Simulate the loadAiActions logic
+    const loadAiActions = async () => {
+      if (process.env.DISABLE_AI_ACTIONS === "true") {
+        return
+      }
+
+      if (!process.env.SPACE_ID) {
+        return
+      }
+
+      await aiActionHandlers.listAiActions({
+        spaceId: process.env.SPACE_ID,
+        environmentId: process.env.ENVIRONMENT_ID || "master",
+        status: "published",
+      })
+    }
+
+    await loadAiActions()
+
+    expect(aiActionHandlers.listAiActions).not.toHaveBeenCalled()
+  })
+
+  it("should load AI Actions when DISABLE_AI_ACTIONS is not set", async () => {
+    delete process.env.DISABLE_AI_ACTIONS
+    process.env.SPACE_ID = "test-space"
+    process.env.ENVIRONMENT_ID = "master"
+
+    vi.mocked(aiActionHandlers.listAiActions).mockResolvedValueOnce({
+      sys: { type: "Array" },
+      items: [],
+      total: 0,
+      skip: 0,
+      limit: 10,
+    })
+
+    // Simulate the loadAiActions logic
+    const loadAiActions = async () => {
+      if (process.env.DISABLE_AI_ACTIONS === "true") {
+        return
+      }
+
+      if (!process.env.SPACE_ID) {
+        return
+      }
+
+      await aiActionHandlers.listAiActions({
+        spaceId: process.env.SPACE_ID,
+        environmentId: process.env.ENVIRONMENT_ID || "master",
+        status: "published",
+      })
+    }
+
+    await loadAiActions()
+
+    expect(aiActionHandlers.listAiActions).toHaveBeenCalledWith({
+      spaceId: "test-space",
+      environmentId: "master",
+      status: "published",
+    })
+  })
+
+  it("should load AI Actions when DISABLE_AI_ACTIONS is set to 'false'", async () => {
+    process.env.DISABLE_AI_ACTIONS = "false"
+    process.env.SPACE_ID = "test-space"
+    process.env.ENVIRONMENT_ID = "master"
+
+    vi.mocked(aiActionHandlers.listAiActions).mockResolvedValueOnce({
+      sys: { type: "Array" },
+      items: [],
+      total: 0,
+      skip: 0,
+      limit: 10,
+    })
+
+    // Simulate the loadAiActions logic
+    const loadAiActions = async () => {
+      if (process.env.DISABLE_AI_ACTIONS === "true") {
+        return
+      }
+
+      if (!process.env.SPACE_ID) {
+        return
+      }
+
+      await aiActionHandlers.listAiActions({
+        spaceId: process.env.SPACE_ID,
+        environmentId: process.env.ENVIRONMENT_ID || "master",
+        status: "published",
+      })
+    }
+
+    await loadAiActions()
+
+    expect(aiActionHandlers.listAiActions).toHaveBeenCalledWith({
+      spaceId: "test-space",
+      environmentId: "master",
+      status: "published",
+    })
+  })
+
+  it("should skip AI Actions loading when SPACE_ID is not set", async () => {
+    delete process.env.DISABLE_AI_ACTIONS
+    delete process.env.SPACE_ID
+
+    // Simulate the loadAiActions logic
+    const loadAiActions = async () => {
+      if (process.env.DISABLE_AI_ACTIONS === "true") {
+        return
+      }
+
+      if (!process.env.SPACE_ID) {
+        return
+      }
+
+      await aiActionHandlers.listAiActions({
+        spaceId: process.env.SPACE_ID,
+        environmentId: process.env.ENVIRONMENT_ID || "master",
+        status: "published",
+      })
+    }
+
+    await loadAiActions()
+
+    expect(aiActionHandlers.listAiActions).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Add option to disable AI Actions fetching on startup for users who don't have access to this feature. Set DISABLE_AI_ACTIONS=true to skip loading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a toggle to skip AI Actions loading at startup across transports.
> 
> - Adds `DISABLE_AI_ACTIONS` env check in `loadAiActions` for both `src/index.ts` and `src/transports/streamable-http.ts` to early-return and avoid cache refresh/fetch
> - Documents new variable in `README.md`
> - Adds unit tests (`test/unit/disable-ai-actions.test.ts`) covering disabled, enabled, and missing `SPACE_ID` scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9385e053f733d5abf89aa10f60e96b961ec77c21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->